### PR TITLE
[Reviewer: Chris] Re-raises alarms every 30 seconds

### DIFF
--- a/src/ut/alarm_test.cpp
+++ b/src/ut/alarm_test.cpp
@@ -191,6 +191,8 @@ TEST_F(AlarmTest, MultiStateAlarmRaising)
   // Causes the test thread to wait to ensure the zmq messages get sent before
   // the test terminates.
   _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
+  _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
+
 }
 
 // Raises a MultiStateAlarm at two of its possible states and then clears it. We
@@ -233,8 +235,10 @@ TEST_F(AlarmTest, MultiStateAlarmClearing)
 // thirty seconds. We should expect three ZMQ messages: the first caused by the
 // alarm being raised, the second and third caused by the function to re-send
 // alarms every 30 seconds. This function reraises the alarm which was raised
-// but also clears the only other defined alarm (as this alarm was not raised,
-// we assume it to be in a CLEARED state).
+// and also clears the only other defined alarm (by design the Alarm Manager
+// assumes this alarm to be CLEARED as it has not received a notification for
+// this alarm). 
+
 TEST_F(AlarmTest, ResendingAlarm)
 {
   {
@@ -272,8 +276,10 @@ TEST_F(AlarmTest, ResendingAlarm)
 // thirty seconds. We should expect four ZMQ messages: the first two caused by the
 // alarm being raised and cleared respectively, the third and fourth caused by the 
 // function to re-send alarms every 30 seconds. This function reclears the alarm which
-// was cleared but also clears the only other defined alarm (as this alarm was not raised,
-// we assume it to be in a CLEARED state).
+// was cleared and also clears the only other defined alarm (by design the Alarm Manager
+// assumes this alarm to be CLEARED as it has not received a notification for
+// this alarm). 
+
 TEST_F(AlarmTest, ResendingClearedAlarm)
 {
   {
@@ -315,11 +321,12 @@ TEST_F(AlarmTest, ResendingClearedAlarm)
 
 // Raises a MultiStateAlarm at two of its possible states and then simulates
 // time moving forward 30 seconds. We should expect four ZMQ messages: the first
-// two caused by the MultiSecerityAlarm changing states, the last two caused
+// two caused by the MultiSeverityAlarm changing states, the last two caused
 // by the function to resend alarms every 30 seconds. This function reraises the 
 // alarm which was raised (at the most recent severity at which it was raised)
-// but also clears the only other defined alarm (as this alarm was not raised,
-// we assume it to be in a CLEARED state).
+// and also clears the only other defined alarm (by design the Alarm Manager
+// assumes this alarm to be CLEARED as it has not received a notification for
+// this alarm). 
 TEST_F(AlarmTest, MultiStateAlarmResending)
 {
   {

--- a/src/ut/alarm_test.cpp
+++ b/src/ut/alarm_test.cpp
@@ -40,6 +40,7 @@
 
 #include "utils.h"
 #include "test_utils.hpp"
+#include "test_interposer.hpp"
 
 #include "alarm.h"
 #include "fakezmq.h"
@@ -62,6 +63,14 @@ MATCHER_P(VoidPointeeEqualsInt, value, "")
 namespace AlarmDef {
 static const int CPP_COMMON_FAKE_ALARM1 = 9999;
 static const int CPP_COMMON_FAKE_ALARM2 = 9998;
+static const int CPP_COMMON_FAKE_ALARM3 = 9997;
+static const int CPP_COMMON_FAKE_ALARM4 = 9996;
+static const int CPP_COMMON_FAKE_ALARM5 = 9995;
+static const int CPP_COMMON_FAKE_ALARM6 = 9994;
+static const int CPP_COMMON_FAKE_ALARM7 = 9993;
+static const int CPP_COMMON_FAKE_ALARM8 = 9992;
+static const int CPP_COMMON_FAKE_ALARM9 = 9991;
+static const int CPP_COMMON_FAKE_ALARM10 = 9990;
 }
 
 class AlarmTest : public ::testing::Test
@@ -70,6 +79,7 @@ public:
   AlarmTest() :
     _alarm_state(issuer, AlarmDef::CPP_COMMON_FAKE_ALARM1, AlarmDef::CRITICAL),
     _alarm(issuer, AlarmDef::CPP_COMMON_FAKE_ALARM2, AlarmDef::MAJOR),
+    _multi_state_alarm(issuer, AlarmDef::CPP_COMMON_FAKE_ALARM3),
     _c(1),
     _s(2)
   {
@@ -103,7 +113,8 @@ public:
     EXPECT_CALL(_mz, zmq_ctx_destroy(VoidPointeeEqualsInt(_c)))
       .Times(1)
       .WillOnce(Return(0));
-
+    
+    AlarmManager::get_instance()._alarm_list.clear();
     AlarmReqAgent::get_instance().stop();
     cwtest_restore_zmq();
   }
@@ -112,10 +123,79 @@ private:
   MockZmqInterface _mz;
   AlarmState _alarm_state;
   Alarm _alarm;
+  MultiStateAlarm _multi_state_alarm;
   int _c;
   int _s;
 };
 
+class MultipleAlarmsTest : public ::testing::Test
+{
+public:
+  MultipleAlarmsTest() :
+    _alarm_state(issuer, AlarmDef::CPP_COMMON_FAKE_ALARM1, AlarmDef::CRITICAL),
+    _alarm(issuer, AlarmDef::CPP_COMMON_FAKE_ALARM2, AlarmDef::MAJOR),
+    _multi_state_alarm(issuer, AlarmDef::CPP_COMMON_FAKE_ALARM3),
+    _alarm4(issuer, AlarmDef::CPP_COMMON_FAKE_ALARM4, AlarmDef::INDETERMINATE),
+    _alarm5(issuer, AlarmDef::CPP_COMMON_FAKE_ALARM5, AlarmDef::WARNING),
+    _alarm6(issuer, AlarmDef::CPP_COMMON_FAKE_ALARM6, AlarmDef::MINOR),
+    _multi_state_alarm7(issuer, AlarmDef::CPP_COMMON_FAKE_ALARM7),
+    _multi_state_alarm8(issuer, AlarmDef::CPP_COMMON_FAKE_ALARM8),
+    _multi_state_alarm9(issuer, AlarmDef::CPP_COMMON_FAKE_ALARM9),
+    _multi_state_alarm10(issuer, AlarmDef::CPP_COMMON_FAKE_ALARM10),
+    _c(1),
+    _s(2)
+  {
+    cwtest_intercept_zmq(&_mz);
+
+    EXPECT_CALL(_mz, zmq_ctx_new())
+      .Times(1)
+      .WillOnce(Return(&_c));
+
+    EXPECT_CALL(_mz, zmq_socket(VoidPointeeEqualsInt(_c),ZMQ_REQ))
+      .Times(1)
+      .WillOnce(Return(&_s));
+
+    EXPECT_CALL(_mz, zmq_setsockopt(VoidPointeeEqualsInt(_s),ZMQ_LINGER,_,_))
+      .Times(1)
+      .WillOnce(Return(0));
+
+    EXPECT_CALL(_mz, zmq_connect(VoidPointeeEqualsInt(_s),StrEq("ipc:///var/run/clearwater/alarms"))) 
+      .Times(1)
+      .WillOnce(Return(0));
+
+    AlarmReqAgent::get_instance().start();
+  }
+
+  virtual ~MultipleAlarmsTest()
+  {
+    EXPECT_CALL(_mz, zmq_close(VoidPointeeEqualsInt(_s)))
+      .Times(1)
+      .WillOnce(Return(0));
+
+    EXPECT_CALL(_mz, zmq_ctx_destroy(VoidPointeeEqualsInt(_c)))
+      .Times(1)
+      .WillOnce(Return(0));
+    
+    AlarmManager::get_instance()._alarm_list.clear();
+    AlarmReqAgent::get_instance().stop();
+    cwtest_restore_zmq();
+  }
+
+private:
+  MockZmqInterface _mz;
+  AlarmState _alarm_state;
+  Alarm _alarm;
+  MultiStateAlarm _multi_state_alarm;
+  Alarm _alarm4;
+  Alarm _alarm5;
+  Alarm _alarm6;
+  MultiStateAlarm _multi_state_alarm7;
+  MultiStateAlarm _multi_state_alarm8;
+  MultiStateAlarm _multi_state_alarm9;
+  MultiStateAlarm _multi_state_alarm10;
+  int _c;
+  int _s;
+};
 class AlarmQueueErrorTest : public ::testing::Test
 {
 public:
@@ -160,6 +240,272 @@ private:
 MATCHER_P(VoidPointeeEqualsStr, value, "") 
 {
   return (strcmp((char*)arg, value) == 0);
+}
+
+TEST_F(AlarmTest, MultiStateAlarmRaising)
+{
+  {
+    InSequence s;
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9997.3"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+    
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9997.4"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+  }
+  // Raises an alarm twice using different states each time. We check above for
+  // two ZMQ messages, the second containing the updated raised state.
+  _multi_state_alarm.multi_set_critical();
+  _multi_state_alarm.multi_set_major();
+  // Causes the test thread to wait to ensure the zmq messages get sent before
+  // the test terminates.
+  for (unsigned int i = 0; i < 2; i++)
+  {
+    _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
+  }
+}
+
+TEST_F(AlarmTest, AlarmAndMultiStateAlarmRaising)
+{
+  {
+    InSequence s;
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9998.4"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+    
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9997.2"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+    
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9997.5"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+  }
+  // Raises an alarm with only one possible raised state and a MultiStateAlarm
+  // raised with two of its possible raised states.
+  _alarm.set();
+  _multi_state_alarm.multi_set_indeterminate();
+  _multi_state_alarm.multi_set_minor();
+  
+  //No further ZMQ messages should be sent for these alarms as they are
+  //attempting to raise a state they are already in.
+  _alarm.set();
+  _multi_state_alarm.multi_set_minor();
+
+  // Causes the test thread to wait to ensure the zmq messages get sent before
+  // the test terminates.
+  for (unsigned int i = 0; i < 3; i++)
+  {
+    _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
+  }
+}
+
+TEST_F(AlarmTest, MultiStateAlarmClearing)
+{
+  {
+    InSequence s;
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9997.6"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+    
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9997.5"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+    
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9997.1"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+  }
+  // Raises a MultiStateAlarm with two of its possible states and then clears
+  // it.
+  _multi_state_alarm.multi_set_warning();
+  _multi_state_alarm.multi_set_minor();
+  _multi_state_alarm.clear();
+  
+  // Causes the test thread to wait to ensure the zmq messages get sent before
+  // the test terminates.
+  for (unsigned int i = 0; i < 3; i++)
+  {
+    _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
+  }
+}
+
+TEST_F(AlarmTest, ResendingAlarm)
+{
+  {
+    InSequence s;
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9998.4"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+    
+    // We should expect the alarm we raised above to be reraised and also the
+    // MultiStateAlarm alarm (which was never raised) should be cleared.
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9998.4"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9997.1"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+  }
+  // Raises an alarm with only one possible raised state.
+  _alarm.set();
+  // Simulates 30 seconds of time passing to trigger the alarms being re-raised.
+  cwtest_advance_time_ms(30000);
+  // Causes the test thread to wait to ensure the zmq messages get sent before
+  // the test terminates.
+  for (unsigned int i = 0; i < 3; i++)
+  {
+    _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
+  }
+}
+
+TEST_F(MultipleAlarmsTest, ResendingAlarmsAndMultiStateAlarms)
+{
+  {
+    InSequence s;
+
+    // These are the ZMQ messages we expect to be sent for the alarms we raise
+    // and clear manually below.
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9998.4"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+    
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9998.1"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9997.2"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9996.2"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+    
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9995.6"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+    
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9993.6"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9993.1"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+    
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9992.5"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+    
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9991.4"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+    
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9991.3"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+
+    // These are the ZMQ messages we expect to be sent automatically by the
+    // function to reraise alarms every thirty seconds.
+    
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9998.1"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9997.2"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+    
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9996.2"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+    
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9995.6"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9994.1"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9993.1"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9992.5"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+    
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9991.3"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+    
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9990.1"),_,_)).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
+
+  }
+  // This test cover a wide range of raising alarm cases to test how they are
+  // reraised every thiry seconds with both single state Alarms and
+  // MultiStateAlarms. These tests include: purposely reraising an alarm with 
+  // the same state (which should only cause one ZMQ message to be sent),
+  // reraising an alarm with a different state (which should cause two ZMQ
+  // messages to be sent, but every thirty seconds only the most recent state
+  // is reraised), not raising the alarm and clearing a raised alarm (which
+  // should both result in the CLEARED status being resent every thiry seconds).
+  _alarm.set();
+  _alarm.clear();
+  _multi_state_alarm.multi_set_indeterminate();
+  _alarm4.set();
+  _alarm5.set();
+  _alarm5.set();
+  _multi_state_alarm7.multi_set_warning();
+  _multi_state_alarm7.clear();
+  _multi_state_alarm8.multi_set_minor();
+  _multi_state_alarm8.multi_set_minor();
+  _multi_state_alarm9.multi_set_major();
+  _multi_state_alarm9.multi_set_critical();
+  // Simulates 30 seconds of time passing to trigger the alarms being re-raised.
+  cwtest_advance_time_ms(30000);
+  // Causes the test thread to wait to ensure the zmq messages get sent before
+  // the test terminates.
+  for (unsigned int i = 0; i < 19; i++)
+  {
+    _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
+  }
 }
 
 TEST_F(AlarmTest, IssueAlarm)

--- a/src/ut/alarm_test.cpp
+++ b/src/ut/alarm_test.cpp
@@ -733,7 +733,7 @@ TEST_F(AlarmZmqErrorTest, CloseSocket)
 
   EXPECT_TRUE(AlarmReqAgent::get_instance().start());
   AlarmReqAgent::get_instance().stop();
-  
+
   EXPECT_TRUE(log.contains("zmq_close failed"));
 }
 

--- a/src/ut/alarm_test.cpp
+++ b/src/ut/alarm_test.cpp
@@ -727,6 +727,7 @@ TEST_F(AlarmZmqErrorTest, CloseSocket)
 
   EXPECT_TRUE(AlarmReqAgent::get_instance().start());
   AlarmReqAgent::get_instance().stop();
+  
   EXPECT_TRUE(log.contains("zmq_close failed"));
 }
 

--- a/src/ut/alarm_test.cpp
+++ b/src/ut/alarm_test.cpp
@@ -188,8 +188,10 @@ TEST_F(AlarmTest, MultiStateAlarmRaising)
   // two ZMQ messages, the second containing the updated raised state.
   _multi_state_alarm.set_critical();
   _multi_state_alarm.set_major();
-  // Causes the test thread to wait to ensure the zmq messages get sent before
-  // the test terminates.
+
+  // Causes the test thread to wait until we receive two zmq_recv messages (to
+  // satisfy the expect_call above). We wait for a maximum of five seconds for
+  // each message.
   _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
   _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
 
@@ -223,8 +225,9 @@ TEST_F(AlarmTest, MultiStateAlarmClearing)
   _multi_state_alarm.set_minor();
   _multi_state_alarm.clear();
   
-  // Causes the test thread to wait to ensure the zmq messages get sent before
-  // the test terminates.
+  // Causes the test thread to wait until we receive three zmq_recv messages (to
+  // satisfy the expect_call above). We wait for a maximum of five seconds for
+  // each message.
   for (unsigned int i = 0; i < 3; i++)
   {
     _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
@@ -264,8 +267,10 @@ TEST_F(AlarmTest, ResendingAlarm)
   _alarm.set();
   // Simulates 30 seconds of time passing to trigger the alarms being re-raised.
   cwtest_advance_time_ms(30000);
-  // Causes the test thread to wait to ensure the zmq messages get sent before
-  // the test terminates.
+
+  // Causes the test thread to wait until we receive three zmq_recv messages (to
+  // satisfy the expect_call above). We wait for a maximum of five seconds for
+  // each message.
   for (unsigned int i = 0; i < 3; i++)
   {
     _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
@@ -311,8 +316,10 @@ TEST_F(AlarmTest, ResendingClearedAlarm)
   _alarm.clear();
   // Simulates 30 seconds of time passing to trigger the alarms being re-raised.
   cwtest_advance_time_ms(30000);
-  // Causes the test thread to wait to ensure the zmq messages get sent before
-  // the test terminates.
+
+  // Causes the test thread to wait until we receive four zmq_recv messages (to
+  // satisfy the expect_call above). We wait for a maximum of five seconds for
+  // each message.
   for (unsigned int i = 0; i < 4; i++)
   {
     _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
@@ -364,8 +371,9 @@ TEST_F(AlarmTest, MultiStateAlarmResending)
   // Simulates 30 seconds of time passing to trigger the alarms being re-raised.
   cwtest_advance_time_ms(30000);
 
-  // Causes the test thread to wait to ensure the zmq messages get sent before
-  // the test terminates.
+  // Causes the test thread to wait until we receive four zmq_recv messages (to
+  // satisfy the expect_call above). We wait for a maximum of five seconds for
+  // each message.
   for (unsigned int i = 0; i < 4; i++)
   {
     _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
@@ -421,8 +429,9 @@ TEST_F(AlarmTest, MultiStateAlarmClearedResending)
   // Simulates 30 seconds of time passing to trigger the alarms being re-raised.
   cwtest_advance_time_ms(30000);
 
-  // Causes the test thread to wait to ensure the zmq messages get sent before
-  // the test terminates.
+  // Causes the test thread to wait until we receive five zmq_recv messages (to
+  // satisfy the expect_call above). We wait for a maximum of five seconds for
+  // each message.
   for (unsigned int i = 0; i < 5; i++)
   {
     _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
@@ -444,8 +453,10 @@ TEST_F(AlarmTest, ResendingAlarmRepeatedSeverity)
   // Raises an alarm twice with only one possible raised state.
   _alarm.set();
   _alarm.set();
-  // Causes the test thread to wait to ensure the zmq messages get sent before
-  // the test terminates.
+  
+  // Causes the test thread to wait until we receive a zmq_recv message (to
+  // satisfy the expect_call above). We wait for a maximum of five seconds for
+  // the message.
   _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
 }
 
@@ -471,8 +482,10 @@ TEST_F(AlarmTest, MultiStateAlarmRepeatedSeverity)
   _multi_state_alarm.set_critical();
   _multi_state_alarm.set_major();
   _multi_state_alarm.set_major();
-  // Causes the test thread to wait to ensure the zmq messages get sent before
-  // the test terminates.
+  
+  // Causes the test thread to wait until we receive two zmq_recv messages (to
+  // satisfy the expect_call above). We wait for a maximum of five seconds for
+  // each message.
   for (unsigned int i = 0; i < 2; i++)
   {
     _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);

--- a/src/ut/alarm_test.cpp
+++ b/src/ut/alarm_test.cpp
@@ -107,7 +107,7 @@ public:
       .Times(1)
       .WillOnce(Return(0));
     
-    AlarmManager::get_instance().alarm_list_clear();
+    AlarmManager::get_instance().forget_alarm_list();
     AlarmReqAgent::get_instance().stop();
     cwtest_restore_zmq();
   }

--- a/src/ut/alarm_test.cpp
+++ b/src/ut/alarm_test.cpp
@@ -167,7 +167,7 @@ MATCHER_P(VoidPointeeEqualsStr, value, "")
   return (strcmp((char*)arg, value) == 0);
 }
 
-// Raise a MultiStateAlarm in two of its possible states and expects two ZMQ
+// Raise a MultiStateAlarm in two of its possible states and expect two ZMQ
 // messages alerting the Alarm Agent of each state change.
 TEST_F(AlarmTest, MultiStateAlarmRaising)
 {
@@ -190,10 +190,7 @@ TEST_F(AlarmTest, MultiStateAlarmRaising)
   _multi_state_alarm.set_major();
   // Causes the test thread to wait to ensure the zmq messages get sent before
   // the test terminates.
-  for (unsigned int i = 0; i < 2; i++)
-  {
-    _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
-  }
+  _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
 }
 
 // Raises a MultiStateAlarm at two of its possible states and then clears it. We
@@ -235,7 +232,9 @@ TEST_F(AlarmTest, MultiStateAlarmClearing)
 // Raises an Alarm (single state) and then simulates time moving forward by
 // thirty seconds. We should expect three ZMQ messages: the first caused by the
 // alarm being raised, the second and third caused by the function to re-send
-// alarms every 30 seconds.
+// alarms every 30 seconds. This function reraises the alarm which was raised
+// but also clears the only other defined alarm (as this alarm was not raised,
+// we assume it to be in a CLEARED state).
 TEST_F(AlarmTest, ResendingAlarm)
 {
   {
@@ -272,7 +271,9 @@ TEST_F(AlarmTest, ResendingAlarm)
 // Raises an Alarm (single state), clears it and then simulates time moving forward by
 // thirty seconds. We should expect four ZMQ messages: the first two caused by the
 // alarm being raised and cleared respectively, the third and fourth caused by the 
-// function to re-send alarms every 30 seconds.
+// function to re-send alarms every 30 seconds. This function reclears the alarm which
+// was cleared but also clears the only other defined alarm (as this alarm was not raised,
+// we assume it to be in a CLEARED state).
 TEST_F(AlarmTest, ResendingClearedAlarm)
 {
   {
@@ -314,8 +315,11 @@ TEST_F(AlarmTest, ResendingClearedAlarm)
 
 // Raises a MultiStateAlarm at two of its possible states and then simulates
 // time moving forward 30 seconds. We should expect four ZMQ messages: the first
-// two caused by the MultiSecerityAlarm changing states, the second two caused
-// by the function to resend alarms every 30 seconds.
+// two caused by the MultiSecerityAlarm changing states, the last two caused
+// by the function to resend alarms every 30 seconds. This function reraises the 
+// alarm which was raised (at the most recent severity at which it was raised)
+// but also clears the only other defined alarm (as this alarm was not raised,
+// we assume it to be in a CLEARED state).
 TEST_F(AlarmTest, MultiStateAlarmResending)
 {
   {
@@ -363,8 +367,10 @@ TEST_F(AlarmTest, MultiStateAlarmResending)
 
 // Raises a MultiStateAlarm at two of its possible states, clears it and then simulates
 // time moving forward 30 seconds. We should expect five ZMQ messages: the first
-// three caused by the MultiSecerityAlarm changing states, the second two caused
-// by the function to resend alarms every 30 seconds.
+// three caused by the MultiSecerityAlarm changing states, the last two caused
+// by the function to resend alarms every 30 seconds. This function reclears the alarm which
+// was cleared but also clears the only other defined alarm (as this alarm was not raised,
+// we assume it to be in a CLEARED state).
 TEST_F(AlarmTest, MultiStateAlarmClearedResending)
 {
   {


### PR DESCRIPTION
Tests both the alarm refactoring (creating a new class called MultiStateAlarms for alarms which can be raised with two or more possible states) and the alarm reraising function (which reraises all alarms every 30 seconds).
