### PR TITLE
[Reviewer: Rob] Alarms reliability

### DIFF
--- a/src/ut/alarm_test.cpp
+++ b/src/ut/alarm_test.cpp
@@ -236,13 +236,9 @@ TEST_F(AlarmTest, MultiStateAlarmClearing)
 }
 
 // Raises an Alarm (single state) and then simulates time moving forward by
-// thirty seconds. We should expect three ZMQ messages: the first caused by the
-// alarm being raised, the second and third caused by the function to re-send
-// alarms every 30 seconds. This function reraises the alarm which was raised
-// and also clears the only other defined alarm (by design the Alarm Manager
-// assumes this alarm to be CLEARED as it has not received a notification for
-// this alarm). 
-
+// thirty seconds. We should expect two ZMQ messages: the first caused by the
+// alarm being raised, the second caused by the function to re-send
+// alarms every 30 seconds. This function reraises the alarm which was raised.
 TEST_F(AlarmTest, ResendingAlarm)
 {
   {
@@ -252,16 +248,10 @@ TEST_F(AlarmTest, ResendingAlarm)
     EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9998.4"),_,_)).Times(1).WillOnce(Return(0));
     EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
     
-    // We should expect the alarm we raised above to be reraised and also the
-    // MultiStateAlarm alarm (which was never raised) should be cleared.
+    // We should expect the alarm we raised above to be reraised.
     EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
     EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
     EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9998.4"),_,_)).Times(1).WillOnce(Return(0));
-    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
-
-    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
-    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
-    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9997.1"),_,_)).Times(1).WillOnce(Return(0));
     EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
   }
   // Raises an alarm with only one possible raised state.
@@ -269,23 +259,19 @@ TEST_F(AlarmTest, ResendingAlarm)
   // Simulates 1000 seconds of time passing to trigger the alarms being re-raised.
   cwtest_advance_time_ms(1000000);
 
-  // Causes the test thread to wait until we receive three zmq_recv messages (to
+  // Causes the test thread to wait until we receive two zmq_recv messages (to
   // satisfy the expect_call above). We wait for a maximum of five seconds for
   // each message.
-  for (unsigned int i = 0; i < 3; i++)
+  for (unsigned int i = 0; i < 2; i++)
   {
     _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
   }
 }
 
 // Raises an Alarm (single state), clears it and then simulates time moving forward by
-// thirty seconds. We should expect four ZMQ messages: the first two caused by the
-// alarm being raised and cleared respectively, the third and fourth caused by the 
-// function to re-send alarms every 30 seconds. This function reclears the alarm which
-// was cleared and also clears the only other defined alarm (by design the Alarm Manager
-// assumes this alarm to be CLEARED as it has not received a notification for
-// this alarm). 
-
+// thirty seconds. We should expect three ZMQ messages: the first two caused by the
+// alarm being raised and cleared respectively, the third caused by the 
+// function to re-send alarms every 30 seconds.
 TEST_F(AlarmTest, ResendingClearedAlarm)
 {
   {
@@ -300,16 +286,10 @@ TEST_F(AlarmTest, ResendingClearedAlarm)
     EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9998.1"),_,_)).Times(1).WillOnce(Return(0));
     EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
 
-    // We should expect the alarm we cleared above to be recleared and also the
-    // MultiStateAlarm alarm (which was never raised) should be cleared.
+    // We should expect the alarm we cleared above to be recleared.
     EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
     EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
     EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9998.1"),_,_)).Times(1).WillOnce(Return(0));
-    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
-
-    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
-    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
-    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9997.1"),_,_)).Times(1).WillOnce(Return(0));
     EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
   }
   // Raises an alarm with only one possible raised state.
@@ -318,23 +298,20 @@ TEST_F(AlarmTest, ResendingClearedAlarm)
   // Simulates 1000 seconds of time passing to trigger the alarms being re-raised.
   cwtest_advance_time_ms(1000000);
 
-  // Causes the test thread to wait until we receive four zmq_recv messages (to
+  // Causes the test thread to wait until we receive three zmq_recv messages (to
   // satisfy the expect_call above). We wait for a maximum of five seconds for
   // each message.
-  for (unsigned int i = 0; i < 4; i++)
+  for (unsigned int i = 0; i < 3; i++)
   {
     _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
   }
 }
 
 // Raises a MultiStateAlarm at two of its possible states and then simulates
-// time moving forward 1000 seconds. We should expect four ZMQ messages: the first
-// two caused by the MultiSeverityAlarm changing states, the last two caused
+// time moving forward 1000 seconds. We should expect three ZMQ messages: the first
+// two caused by the MultiSeverityAlarm changing states, the last caused
 // by the function to resend alarms every 30 seconds. This function reraises the 
-// alarm which was raised (at the most recent severity at which it was raised)
-// and also clears the only other defined alarm (by design the Alarm Manager
-// assumes this alarm to be CLEARED as it has not received a notification for
-// this alarm). 
+// alarm which was raised (at the most recent severity at which it was raised).
 TEST_F(AlarmTest, MultiStateAlarmResending)
 {
   {
@@ -351,13 +328,7 @@ TEST_F(AlarmTest, MultiStateAlarmResending)
     EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
     
     // After we simulate time moving forward 1000 seconds we should expect the
-    // single state Alarm with index 9998 to be cleared (as it was never raised)
-    // and the MultiStateAlarm to be re-raised at its latest severity (9997.4).
-    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
-    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
-    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9998.1"),_,_)).Times(1).WillOnce(Return(0));
-    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
-    
+    // MultiStateAlarm to be re-raised at its latest severity (9997.4).
     EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
     EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
     EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9997.4"),_,_)).Times(1).WillOnce(Return(0));
@@ -372,21 +343,20 @@ TEST_F(AlarmTest, MultiStateAlarmResending)
   // Simulates 1000 seconds of time passing to trigger the alarms being re-raised.
   cwtest_advance_time_ms(1000000);
 
-  // Causes the test thread to wait until we receive four zmq_recv messages (to
+  // Causes the test thread to wait until we receive three zmq_recv messages (to
   // satisfy the expect_call above). We wait for a maximum of five seconds for
   // each message.
-  for (unsigned int i = 0; i < 4; i++)
+  for (unsigned int i = 0; i < 3; i++)
   {
     _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
   }
 }
 
 // Raises a MultiStateAlarm at two of its possible states, clears it and then simulates
-// time moving forward 1000 seconds. We should expect five ZMQ messages: the first
-// three caused by the MultiSecerityAlarm changing states, the last two caused
-// by the function to resend alarms every 30 seconds. This function reclears the alarm which
-// was cleared but also clears the only other defined alarm (as this alarm was not raised,
-// we assume it to be in a CLEARED state).
+// time moving forward 1000 seconds. We should expect four ZMQ messages: the first
+// three caused by the MultiSecerityAlarm changing states, the last caused
+// by the function to resend alarms every 30 seconds. This function reclears
+// the alarm which was cleared.
 TEST_F(AlarmTest, MultiStateAlarmClearedResending)
 {
   {
@@ -407,14 +377,8 @@ TEST_F(AlarmTest, MultiStateAlarmClearedResending)
     EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9997.1"),_,_)).Times(1).WillOnce(Return(0));
     EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
 
-    // After we simulate time moving forward 1000 seconds we should expect the
-    // single state Alarm with index 9998 to be cleared (as it was never raised)
-    // and the MultiStateAlarm to be re-cleared.
-    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
-    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
-    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9998.1"),_,_)).Times(1).WillOnce(Return(0));
-    EXPECT_CALL(_mz, zmq_recv(_,_,_,_)).Times(1).WillOnce(Return(0));
-    
+    // After we simulate time moving forward 1000 seconds we should expect
+    // the MultiStateAlarm to be re-cleared.
     EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("issue-alarm"),_,_)).Times(1).WillOnce(Return(0));
     EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),_,_)).Times(1).WillOnce(Return(0));
     EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("9997.1"),_,_)).Times(1).WillOnce(Return(0));
@@ -430,10 +394,10 @@ TEST_F(AlarmTest, MultiStateAlarmClearedResending)
   // Simulates 1000 seconds of time passing to trigger the alarms being re-raised.
   cwtest_advance_time_ms(1000000);
 
-  // Causes the test thread to wait until we receive five zmq_recv messages (to
+  // Causes the test thread to wait until we receive four zmq_recv messages (to
   // satisfy the expect_call above). We wait for a maximum of five seconds for
   // each message.
-  for (unsigned int i = 0; i < 5; i++)
+  for (unsigned int i = 0; i < 4; i++)
   {
     _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
   }
@@ -518,27 +482,6 @@ TEST_F(AlarmTest, IssueAlarm)
   _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
 }
 
-TEST_F(AlarmTest, ClearAlarms)
-{
-  {
-    InSequence s;
-
-    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr("clear-alarms"),12,ZMQ_SNDMORE))
-      .Times(1)
-      .WillOnce(Return(0));
-
-    EXPECT_CALL(_mz, zmq_send(_,VoidPointeeEqualsStr(issuer),strlen(issuer),0))
-      .Times(1)
-      .WillOnce(Return(0));
-
-    EXPECT_CALL(_mz, zmq_recv(_,_,_,_))
-      .Times(1)
-      .WillOnce(Return(0));
-  }
-  AlarmState::clear_all(issuer);
-  _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
-}
-
 TEST_F(AlarmTest, PairSetNotAlarmed)
 {
   InSequence s;
@@ -563,6 +506,10 @@ TEST_F(AlarmTest, PairSetNotAlarmed)
   _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
 }
 
+// Tests that the first time an alarm is set the right zmq messages are sent,
+// but that subsequent settings send no zmq messages.
+// The 'Times(3)' on the first call is to cover the three separate messages
+// seen in the tests above: 'issue-alarm', 'issuer', and 'index/severity'.
 TEST_F(AlarmTest, PairSetAlarmed)
 {
   {
@@ -584,12 +531,30 @@ TEST_F(AlarmTest, PairSetAlarmed)
   _alarm.set();
 }
 
+// Tests that the first time an alarm is cleared the right zmq messages are sent,
+// but that subsequent clearings send no zmq messages. 
 TEST_F(AlarmTest, PairClearNotAlarmed)
 {
+  {
+    InSequence s;
+
+    EXPECT_CALL(_mz, zmq_send(_,_,_,_))
+      .Times(3)
+      .WillRepeatedly(Return(0));
+
+    EXPECT_CALL(_mz, zmq_recv(_,_,_,_))
+      .Times(1)
+      .WillOnce(Return(0));
+
+    _alarm.clear();
+    _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
+  }
+
   EXPECT_CALL(_mz, zmq_send(_,_,_,_)).Times(0);
   _alarm.clear();
 }
 
+//Tests that clearing a set alarm sends the right zmq messages.
 TEST_F(AlarmTest, PairClearAlarmed)
 {
   {

--- a/src/ut/alarm_test.cpp
+++ b/src/ut/alarm_test.cpp
@@ -270,7 +270,7 @@ TEST_F(AlarmTest, ResendingAlarm)
 
 // Raises an Alarm (single state), clears it and then simulates time moving forward by
 // thirty seconds. We should expect three ZMQ messages: the first two caused by the
-// alarm being raised and cleared respectively, the third caused by the 
+// alarm being raised and cleared respectively, the third caused by the
 // function to re-send alarms every 30 seconds.
 TEST_F(AlarmTest, ResendingClearedAlarm)
 {
@@ -532,7 +532,7 @@ TEST_F(AlarmTest, PairSetAlarmed)
 }
 
 // Tests that the first time an alarm is cleared the right zmq messages are sent,
-// but that subsequent clearings send no zmq messages. 
+// but that subsequent clearings send no zmq messages.
 TEST_F(AlarmTest, PairClearNotAlarmed)
 {
   {

--- a/src/ut/alarm_test.cpp
+++ b/src/ut/alarm_test.cpp
@@ -202,7 +202,7 @@ TEST_F(AlarmTest, MultiStateAlarmRaising)
 TEST_F(AlarmTest, GetAlarmStateSimpleTest)
 {
   // The single state alarm should start in UNKNOWN state
-  ASSERT_EQ(UNKNOWN, _alarm.get_alarm_state());
+  ASSERT_EQ(AlarmState::UNKNOWN, _alarm.get_alarm_state());
 
   // Set alarm, and assert it is now ALARMED
   {
@@ -219,7 +219,7 @@ TEST_F(AlarmTest, GetAlarmStateSimpleTest)
     _alarm.set();
     _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
   }
-  ASSERT_EQ(ALARMED, _alarm.get_alarm_state());
+  ASSERT_EQ(AlarmState::ALARMED, _alarm.get_alarm_state());
 
   // Clear alarm, and assert it is now CLEARED
   {
@@ -236,14 +236,14 @@ TEST_F(AlarmTest, GetAlarmStateSimpleTest)
     _alarm.clear();
     _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
   }
-  ASSERT_EQ(CLEARED, _alarm.get_alarm_state());
+  ASSERT_EQ(AlarmState::CLEARED, _alarm.get_alarm_state());
 }
 
 // Tests that get_alarm_state returns the correct states for a multi-state alarm.
 TEST_F(AlarmTest, GetAlarmStateMultiStateTest)
 {
   // The multi state alarm should start in UNKNOWN state
-  ASSERT_EQ(UNKNOWN, _multi_state_alarm.get_alarm_state());
+  ASSERT_EQ(AlarmState::UNKNOWN, _multi_state_alarm.get_alarm_state());
 
   // Raise alarm at one severity, and assert it is now ALARMED
   {
@@ -260,7 +260,7 @@ TEST_F(AlarmTest, GetAlarmStateMultiStateTest)
     _multi_state_alarm.set_major();
     _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
   }
-  ASSERT_EQ(ALARMED, _multi_state_alarm.get_alarm_state());
+  ASSERT_EQ(AlarmState::ALARMED, _multi_state_alarm.get_alarm_state());
 
   // Raise alarm at another severity, and assert is is still ALARMED
   {
@@ -277,7 +277,7 @@ TEST_F(AlarmTest, GetAlarmStateMultiStateTest)
     _multi_state_alarm.set_critical();
     _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
   }
-  ASSERT_EQ(ALARMED, _multi_state_alarm.get_alarm_state());
+  ASSERT_EQ(AlarmState::ALARMED, _multi_state_alarm.get_alarm_state());
 
   // Clear alarm, and assert it is not CLEARED
   {
@@ -294,7 +294,7 @@ TEST_F(AlarmTest, GetAlarmStateMultiStateTest)
     _multi_state_alarm.clear();
     _mz.call_complete(ZmqInterface::ZMQ_RECV, 5);
   }
-  ASSERT_EQ(CLEARED, _multi_state_alarm.get_alarm_state());
+  ASSERT_EQ(AlarmState::CLEARED, _multi_state_alarm.get_alarm_state());
 }
 
 // Raises a MultiStateAlarm at two of its possible states and then clears it. We

--- a/src/ut/communicationmonitor_test.cpp
+++ b/src/ut/communicationmonitor_test.cpp
@@ -133,7 +133,7 @@ TEST_F(CommunicationMonitorTest, OnlyErrorsToNoErrorsUpdate)
   _cm.inform_success();
 }
 
-// Test when going from the same state to the same state the alarm state is re-raised 
+// Test when going from the same state to the same state the alarm state is re-raised.
 TEST_F(CommunicationMonitorTest, StableStates)
 {
   // Send in two NO_ERROR states

--- a/src/ut/communicationmonitor_test.cpp
+++ b/src/ut/communicationmonitor_test.cpp
@@ -73,12 +73,12 @@ TEST_F(CommunicationMonitorTest, ErrorsStateIncrement)
 {
   // Pass in a success and failure to update the communication monitor at the
   // same time. We do this by setting one, advancing time beyond the 'next_check'
-  // interval, and then setting the other. This should not set or clear any alarm.
+  // interval, and then setting the other. This should clear the alarm.
   _cm.inform_success();
   cwtest_advance_time_ms(16000);
 
   EXPECT_CALL(*_ma, set()).Times(0);
-  EXPECT_CALL(*_ma, clear()).Times(0);
+  EXPECT_CALL(*_ma, clear()).Times(1);
   _cm.inform_failure();
 
   // Now we set a failure after the set_confirm interval has passed again.
@@ -109,10 +109,10 @@ TEST_F(CommunicationMonitorTest, ErrorStateDecrement)
   _cm.inform_failure();
 
   // Pass in a success after the set_confirm interval has passed again.
-  // This should not change anything.
+  // This should re-clear the alarm.
   cwtest_advance_time_ms(16000);
   EXPECT_CALL(*_ma, set()).Times(0);
-  EXPECT_CALL(*_ma, clear()).Times(0);
+  EXPECT_CALL(*_ma, clear()).Times(1);
   _cm.inform_success();
 }
 
@@ -133,29 +133,29 @@ TEST_F(CommunicationMonitorTest, OnlyErrorsToNoErrorsUpdate)
   _cm.inform_success();
 }
 
-// Test when going from the same state to the same state there's no action taken
+// Test when going from the same state to the same state the alarm state is re-raised 
 TEST_F(CommunicationMonitorTest, StableStates)
 {
   // Send in two NO_ERROR states
   cwtest_advance_time_ms(16000);
   EXPECT_CALL(*_ma, set()).Times(0);
-  EXPECT_CALL(*_ma, clear()).Times(0);
+  EXPECT_CALL(*_ma, clear()).Times(1);
   _cm.inform_success();
   cwtest_advance_time_ms(16000);
   EXPECT_CALL(*_ma, set()).Times(0);
-  EXPECT_CALL(*_ma, clear()).Times(0);
+  EXPECT_CALL(*_ma, clear()).Times(1);
   _cm.inform_success();
 
   // Send in two SOME_ERROR states
   _cm.inform_success();
   cwtest_advance_time_ms(16000);
   EXPECT_CALL(*_ma, set()).Times(0);
-  EXPECT_CALL(*_ma, clear()).Times(0);
+  EXPECT_CALL(*_ma, clear()).Times(1);
   _cm.inform_failure();
   _cm.inform_success();
   cwtest_advance_time_ms(16000);
   EXPECT_CALL(*_ma, set()).Times(0);
-  EXPECT_CALL(*_ma, clear()).Times(0);
+  EXPECT_CALL(*_ma, clear()).Times(1);
   _cm.inform_failure();
 
   // Send in two ONLY_ERROR states
@@ -164,7 +164,7 @@ TEST_F(CommunicationMonitorTest, StableStates)
   EXPECT_CALL(*_ma, clear()).Times(0);
   _cm.inform_failure();
   cwtest_advance_time_ms(31000);
-  EXPECT_CALL(*_ma, set()).Times(0);
+  EXPECT_CALL(*_ma, set()).Times(1);
   EXPECT_CALL(*_ma, clear()).Times(0);
   _cm.inform_failure();
 }
@@ -174,13 +174,13 @@ TEST_F(CommunicationMonitorTest, StableStates)
 // time has advanced by the set_confirm_ms interval at the time of update.
 TEST_F(CommunicationMonitorTest, TestSetConfirmMs)
 {
-  // Run through an update with a success and failure together. This should do nothing.
+  // Run through an update with a success and failure together. This should clear the alarm.
   // This will set us to the SOME_ERRORS state, and set the next_check interval to now + set_confirm_ms.
   _cm.inform_success();
   cwtest_advance_time_ms(16000);
 
   EXPECT_CALL(*_ma, set()).Times(0);
-  EXPECT_CALL(*_ma, clear()).Times(0);
+  EXPECT_CALL(*_ma, clear()).Times(1);
   _cm.inform_failure();
 
   // Advance time by less than the set_confirm interval, and set a failure.


### PR DESCRIPTION
UT changes linked to changes to cpp-common alarms. 
- Tests for the new get_alarm_state function
- Alterations to handle new behaviour of alarms starting in UNKNOWN state, and therefore not being sent until explicitly cleared or set.
- Alterations to handle new communication_monitor behaviour.
