### PR TITLE
[No reviewer] Don't check the alarms string in UT

### DIFF
--- a/src/ut/alarm_test.cpp
+++ b/src/ut/alarm_test.cpp
@@ -90,7 +90,7 @@ public:
       .Times(1)
       .WillOnce(Return(0));
 
-    EXPECT_CALL(_mz, zmq_connect(VoidPointeeEqualsInt(_s),StrEq("ipc:///var/run/clearwater/alarms"))) 
+    EXPECT_CALL(_mz, zmq_connect(VoidPointeeEqualsInt(_s),_))
       .Times(1)
       .WillOnce(Return(0));
 


### PR DESCRIPTION
Fixes a failure triggered by https://github.com/Metaswitch/cpp-common/pull/496.
