### PR TITLE
[Reviewer: Adam] Move utils to be covered

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -105,7 +105,8 @@ cpp_common_test_test_LDFLAGS := -L../usr/lib \
                                 -lcurl \
                                 `net-snmp-config --netsnmp-agent-libs`
 
-COVERAGE_ROOT := ../modules/cpp-common/src
+COVERAGE_ROOT := ../modules/cpp-common
+cpp_common_test_test_COVERAGE_EXCLUSIONS := ^include|^test_utils
 
 cpp_common_test_test_VALGRIND_ARGS := --suppressions=ut/cpp_common_test.supp
 

--- a/src/ut/coverage-not-yet
+++ b/src/ut/coverage-not-yet
@@ -1,44 +1,45 @@
 # Test code
-localstore.cpp
+src/localstore.cpp
 
 # TODO - covered in clearwater-fv-test. We should have something that checks
 # coverage there before we make it OK to not cover here
-snmp_agent.cpp
-snmp_continuous_accumulator_table.cpp
-snmp_cx_counter_table.cpp
-snmp_event_accumulator_table.cpp
-snmp_infinite_base_table.cpp
-snmp_infinite_scalar_table.cpp
-snmp_infinite_timer_count_table.cpp
-snmp_row.cpp
-snmp_ip_row.cpp
-snmp_single_count_by_node_type_table.cpp
-snmp_success_fail_count_table.cpp
-timer_counter.cpp
-memcachedstore.cpp
-dnsparser.cpp
+src/snmp_agent.cpp
+src/snmp_continuous_accumulator_table.cpp
+src/snmp_cx_counter_table.cpp
+src/snmp_event_accumulator_table.cpp
+src/snmp_infinite_base_table.cpp
+src/snmp_infinite_scalar_table.cpp
+src/snmp_infinite_timer_count_table.cpp
+src/snmp_row.cpp
+src/snmp_ip_row.cpp
+src/snmp_single_count_by_node_type_table.cpp
+src/snmp_success_fail_count_table.cpp
+src/timer_counter.cpp
+src/memcachedstore.cpp
+src/dnsparser.cpp
 
 # TODO - Incomplete coverage
-diameterstack.cpp
-dnscachedresolver.cpp
-astaire_resolver.cpp
+src/diameterstack.cpp
+src/dnscachedresolver.cpp
+src/astaire_resolver.cpp
 
 # TODO - Coverage in the wrong place
 
 # Memento/Homestead
-cassandra_store.cpp
+src/cassandra_store.cpp
 
 # Sprout
-health_checker.cpp
-accumulator.cpp
-statistic.cpp
-counter.cpp
-zmq_lvc.cpp
+src/health_checker.cpp
+src/accumulator.cpp
+src/statistic.cpp
+src/counter.cpp
+src/zmq_lvc.cpp
+src/utils.cpp
 
 # TODO - No coverage
-accesslogger.cpp
-exception_handler.cpp
-namespace_hop.cpp
-base64.cpp
-ipv6utils.cpp
-unique.cpp
+src/accesslogger.cpp
+src/exception_handler.cpp
+src/namespace_hop.cpp
+src/base64.cpp
+src/ipv6utils.cpp
+src/unique.cpp


### PR DESCRIPTION
Gcovr can't deal with files that start with "uti" (I don't know why).
This change moves how the files to cover are calculated, so that everything starts with "src/"
