### PR TITLE
[Reviewer: Ellie] Retire HttpConnection override_server capability

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -18,6 +18,7 @@ cpp_common_test_test_SOURCES := accesslogger.cpp \
                                 exception_handler.cpp \
                                 health_checker.cpp \
                                 http_connection_pool.cpp \
+                                httpclient.cpp \
                                 httpconnection.cpp \
                                 httpresolver.cpp \
                                 httpstack.cpp \

--- a/src/ut/httpconnection_test.cpp
+++ b/src/ut/httpconnection_test.cpp
@@ -280,17 +280,6 @@ TEST_F(HttpConnectionTest, SimpleGetRetry)
   EXPECT_EQ("<message>Gotcha!</message>", output);
 }
 
-TEST_F(HttpConnectionTest, GetWithOverride)
-{
-  string output;
-  std::vector<std::string> headers_in_req;
-  headers_in_req.push_back("Range: 100");
-
-  long ret = _http->send_get("/path", output, headers_in_req, "10.42.42.42:80", 0);
-
-  EXPECT_EQ(200, ret);
-}
-
 TEST_F(HttpConnectionTest, GetWithUsername)
 {
   string output;
@@ -359,13 +348,6 @@ TEST_F(HttpConnectionTest, DeleteBodyWithResponse)
 {
   std::string response;
   long ret = _http->send_delete("/delete_id", 0, "body", response);
-
-  EXPECT_EQ(200, ret);
-}
-
-TEST_F(HttpConnectionTest, DeleteBodyWithOverride)
-{
-  long ret = _http->send_delete("/path", 0, "body", "10.42.42.42:80");
 
   EXPECT_EQ(200, ret);
 }


### PR DESCRIPTION
Just a simple one - removing the UTs for the override_server function, as I've retired it.
