### PR TITLE
[Reviewer: AJH] Add HTTP Lazy Targeting UTs

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -18,6 +18,7 @@ cpp_common_test_test_SOURCES := accesslogger.cpp \
                                 exception_handler.cpp \
                                 health_checker.cpp \
                                 http_connection_pool.cpp \
+                                httpclient.cpp \
                                 httpconnection.cpp \
                                 httpresolver.cpp \
                                 httpstack.cpp \

--- a/src/ut/baseresolver_test.cpp
+++ b/src/ut/baseresolver_test.cpp
@@ -318,12 +318,18 @@ TEST_F(BaseResolverTest, ARecordMakeUpUsedGray)
 TEST_F(BaseResolverTest, ARecordIteratorNextReturnValue)
 {
   AddrInfo record;
+  AddrInfo expected_record = ip_to_addr_info("3.0.0.0");
 
   add_white_records(1);
   BaseResolver::Iterator it = resolve_iter();
 
+  // The value of record should be set by the iterator.
   EXPECT_TRUE(it.next(record));
+  EXPECT_EQ(record, expected_record);
+
+  // The value of record should be left unchanged by the iterator.
   EXPECT_FALSE(it.next(record));
+  EXPECT_EQ(record, expected_record);
 }
 
 /// Test that the lazy target selection iterator uses the state of each Host at

--- a/src/ut/baseresolver_test.cpp
+++ b/src/ut/baseresolver_test.cpp
@@ -349,6 +349,8 @@ TEST_F(BaseResolverTest, ARecordEmptyIteratorNext)
   // The value of record should be left unchanged by the iterator.
   EXPECT_FALSE(it->next(record));
   EXPECT_EQ(record, expected_record);
+
+  delete it; it = nullptr;
 }
 
 /// Test that the lazy target selection iterator functions correctly when there
@@ -358,6 +360,8 @@ TEST_F(BaseResolverTest, ARecordEmptyIteratorTake)
   BaseAddrIterator* it = resolve_iter();
   std::vector<AddrInfo> results = it->take(1);
   EXPECT_EQ(results.size(), 0);
+
+  delete it; it = nullptr;
 }
 
 TEST_F(BaseResolverTest, ARecordIteratorTakeAll)
@@ -370,6 +374,8 @@ TEST_F(BaseResolverTest, ARecordIteratorTakeAll)
 
   results = it->take(5);
   EXPECT_EQ(results.size(), 0);
+
+  delete it; it = nullptr;
 }
 
 TEST_F(BaseResolverTest, ARecordIteratorTakeSome)
@@ -384,6 +390,8 @@ TEST_F(BaseResolverTest, ARecordIteratorTakeSome)
   std::vector<AddrInfo> results_2 = it->take(1);
   ASSERT_EQ(results_2.size(), 1);
   EXPECT_THAT(results_1, Not(Contains(results_2[0])));
+
+  delete it; it = nullptr;
 }
 
 /// Test that the lazy target selection iterator functions correctly when too
@@ -395,6 +403,8 @@ TEST_F(BaseResolverTest, ARecordIteratorTakeTooMany)
 
   std::vector<AddrInfo> results = it->take(5);
   EXPECT_EQ(results.size(), 3);
+
+  delete it; it = nullptr;
 }
 
 /// Test that the lazy target selection iterator functions correctly when
@@ -414,6 +424,8 @@ TEST_F(BaseResolverTest, ARecordIteratorMixTakeAndNext)
   AddrInfo result_2;
   EXPECT_TRUE(it->next(result_2));
   EXPECT_THAT(results, Not(Contains(result_2)));
+
+  delete it; it = nullptr;
 }
 
 /// Test that the lazy target selection iterator uses the state of each Host at

--- a/src/ut/baseresolver_test.cpp
+++ b/src/ut/baseresolver_test.cpp
@@ -336,7 +336,7 @@ TEST_F(BaseResolverTest, ARecordIteratorIsLazy)
   AddrInfo black_to_gray_record = ip_to_addr_info("3.0.0.0");
   _baseresolver.blacklist(black_to_gray_record);
 
-  // Get an iterator, and make a call to next
+  // Get an iterator
   BaseResolver::Iterator it = resolve_iter();
 
   // Move the record to the graylist
@@ -344,7 +344,7 @@ TEST_F(BaseResolverTest, ARecordIteratorIsLazy)
 
   // The record should be returned by the next call to the iterator
   AddrInfo record;
-  it.next(record);
+  EXPECT_TRUE(it.next(record));
   EXPECT_EQ(record, black_to_gray_record);
 }
 

--- a/src/ut/chronosconnection_test.cpp
+++ b/src/ut/chronosconnection_test.cpp
@@ -39,7 +39,7 @@
 
 #include "utils.h"
 #include "sas.h"
-#include "mock_http_resolver.h"
+#include "fakehttpresolver.hpp"
 #include "chronosconnection.h"
 #include "basetest.hpp"
 #include "curl_interposer.hpp"
@@ -49,7 +49,6 @@ namespace AlarmDef {
   static const int CPP_COMMON_FAKE_ALARM = 9999;
 }
 
-using ::testing::_;
 using namespace std;
 
 /// Fixture for ChronosConnectionTest.

--- a/src/ut/chronosconnection_test.cpp
+++ b/src/ut/chronosconnection_test.cpp
@@ -39,7 +39,7 @@
 
 #include "utils.h"
 #include "sas.h"
-#include "mockhttpresolver.h"
+#include "mock_http_resolver.h"
 #include "chronosconnection.h"
 #include "basetest.hpp"
 #include "curl_interposer.hpp"

--- a/src/ut/chronosconnection_test.cpp
+++ b/src/ut/chronosconnection_test.cpp
@@ -55,7 +55,7 @@ using namespace std;
 /// Fixture for ChronosConnectionTest.
 class ChronosConnectionTest : public BaseTest
 {
-  MockHttpResolver _resolver;
+  FakeHttpResolver _resolver;
   AlarmManager* _alarm_manager;
   CommunicationMonitor* _cm;
   ChronosConnection* _chronos;
@@ -64,7 +64,7 @@ class ChronosConnectionTest : public BaseTest
     _alarm_manager(new AlarmManager()),
     _cm(new CommunicationMonitor(new Alarm(_alarm_manager, "sprout", AlarmDef::CPP_COMMON_FAKE_ALARM, AlarmDef::MAJOR), "sprout", "chronos"))
   {
-    _resolver.targets.push_back(MockHttpResolver::create_target("10.42.42.42"));
+    _resolver._targets.push_back(FakeHttpResolver::create_target("10.42.42.42"));
     _chronos = new ChronosConnection("narcissus", "localhost:9888", &_resolver, _cm);
     fakecurl_responses.clear();
   }
@@ -81,7 +81,6 @@ class ChronosConnectionTest : public BaseTest
 TEST_F(ChronosConnectionTest, SendDelete)
 {
   fakecurl_responses["http://10.42.42.42:80/timers/delete_id"] = CURLE_OK;
-  EXPECT_CALL(_resolver, success(_));
   HTTPCode status = _chronos->send_delete("delete_id",  0);
   EXPECT_EQ(status, 200);
 }
@@ -96,7 +95,6 @@ TEST_F(ChronosConnectionTest, SendPost)
 {
   std::list<std::string> headers = {"Location: http://localhost:7253/timers/abcd"};
   fakecurl_responses["http://10.42.42.42:80/timers"] = Response(headers);
-  EXPECT_CALL(_resolver, success(_));
 
   std::string opaque = "{\"aor_id\": \"aor_id\", \"binding_id\": \"binding_id\"}";
   std::string post_identity = "";
@@ -109,7 +107,6 @@ TEST_F(ChronosConnectionTest, SendPostWithTags)
 {
   std::list<std::string> headers = {"Location: http://localhost:7253/timers/abcd"};
   fakecurl_responses["http://10.42.42.42:80/timers"] = Response(headers);
-  EXPECT_CALL(_resolver, success(_));
 
   std::string opaque = "{\"aor_id\": \"aor_id\", \"binding_id\": \"binding_id\"}";
   std::map<std::string, uint32_t> tags = { {"TAG1", 1}, {"TAG2", 1} };
@@ -123,7 +120,6 @@ TEST_F(ChronosConnectionTest, SendPostWithNoLocationHeader)
 {
   std::list<std::string> headers = {"Header: header"};
   fakecurl_responses["http://10.42.42.42:80/timers"] = Response(headers);
-  EXPECT_CALL(_resolver, success(_));
 
   std::string opaque = "{\"aor_id\": \"aor_id\", \"binding_id\": \"binding_id\"}";
   std::string post_identity = "";
@@ -136,7 +132,6 @@ TEST_F(ChronosConnectionTest, SendPostWithNoHeaders)
 {
   std::list<std::string> headers = {""};
   fakecurl_responses["http://10.42.42.42:80/timers"] = Response(headers);
-  EXPECT_CALL(_resolver, success(_));
 
   std::string opaque = "{\"aor_id\": \"aor_id\", \"binding_id\": \"binding_id\"}";
   std::string post_identity = "";
@@ -149,7 +144,6 @@ TEST_F(ChronosConnectionTest, SendPut)
 {
   std::list<std::string> headers = {"Location: http://localhost:7253/timers/efgh"};
   fakecurl_responses["http://10.42.42.42:80/timers/abcd"] = Response(headers);
-  EXPECT_CALL(_resolver, success(_));
 
   // We expect Chronos to change the put identity to the value in the Location
   // header.
@@ -164,7 +158,6 @@ TEST_F(ChronosConnectionTest, SendPutWithTags)
 {
   std::list<std::string> headers = {"Location: http://localhost:7253/timers/efgh"};
   fakecurl_responses["http://10.42.42.42:80/timers/abcd"] = Response(headers);
-  EXPECT_CALL(_resolver, success(_));
 
   // We expect Chronos to change the put identity to the value in the Location
   // header.
@@ -180,7 +173,6 @@ TEST_F(ChronosConnectionTest, SendPutWithNoLocationHeader)
 {
   std::list<std::string> headers = {"Header: header"};
   fakecurl_responses["http://10.42.42.42:80/timers/abcd"] = Response(headers);
-  EXPECT_CALL(_resolver, success(_));
 
   std::string opaque = "{\"aor_id\": \"aor_id\", \"binding_id\": \"binding_id\"}";
   std::string put_identity = "abcd";

--- a/src/ut/httpconnection_test.cpp
+++ b/src/ut/httpconnection_test.cpp
@@ -60,18 +60,19 @@ using ::testing::MatchesRegex;
 using ::testing::_;
 using ::testing::NiceMock;
 using ::testing::StrictMock;
+using ::testing::Return;
 
-// Fixture for tests using fake resolver
+/// Fixture for test.
 class HttpConnectionTest : public BaseTest
 {
   LoadMonitor _lm;
   FakeHttpResolver _resolver;
   AlarmManager* _am = new AlarmManager();
-  NiceMock<MockCommunicationMonitor>*_cm = new NiceMock<MockCommunicationMonitor>(_am);
+  NiceMock<MockCommunicationMonitor>* _cm = new NiceMock<MockCommunicationMonitor>(_am);
   HttpConnection* _http;
-
   HttpConnectionTest() :
-    _lm(100000, 20, 10, 10)
+    _lm(100000, 20, 10, 10),
+    _resolver("10.42.42.42")
   {
     _http = new HttpConnection("cyrus",
                                true,
@@ -80,7 +81,22 @@ class HttpConnectionTest : public BaseTest
                                &_lm,
                                SASEvent::HttpLogLevel::PROTOCOL,
                                _cm);
+
     fakecurl_responses.clear();
+    fakecurl_responses["http://10.42.42.42:80/blah/blah/blah"] = "<?xml version=\"1.0\" encoding=\"UTF-8\"><boring>Document</boring>";
+    fakecurl_responses["http://10.42.42.42:80/blah/blah/wot"] = CURLE_REMOTE_FILE_NOT_FOUND;
+    fakecurl_responses["http://10.42.42.42:80/blah/blah/503"] = 503;
+    fakecurl_responses["http://10.42.42.42:80/blah/blah/recv_error"] = CURLE_RECV_ERROR;
+    fakecurl_responses["http://10.42.42.42:80/up/up/up"] = "<message>ok, whatever...</message>";
+    fakecurl_responses["http://10.42.42.42:80/up/up/down"] = CURLE_REMOTE_ACCESS_DENIED;
+    fakecurl_responses["http://10.42.42.42:80/down/down/down"] = "<message>WHOOOOSH!!</message>";
+    fakecurl_responses["http://10.42.42.42:80/down/down/up"] = CURLE_RECV_ERROR;
+    fakecurl_responses["http://10.42.42.42:80/down/around"] = Response(CURLE_SEND_ERROR, "<message>Gotcha!</message>");
+    fakecurl_responses["http://10.42.42.42:80/delete_id"] = CURLE_OK;
+    fakecurl_responses["http://10.42.42.42:80/put_id"] = CURLE_OK;
+    fakecurl_responses["http://10.42.42.42:80/put_id_response"] = Response({"response"});
+    fakecurl_responses["http://10.42.42.42:80/post_id"] = Response({"Location: test"});
+    fakecurl_responses["http://10.42.42.42:80/path"] = CURLE_OK;
   }
 
   virtual ~HttpConnectionTest()
@@ -93,7 +109,7 @@ class HttpConnectionTest : public BaseTest
   }
 };
 
-// Fixture for blacklist tests using mock resolver
+/// Fixture for blacklist test.
 class HttpConnectionBlacklistTest : public BaseTest
 {
   StrictMock<MockHttpResolver> _resolver;
@@ -113,6 +129,15 @@ class HttpConnectionBlacklistTest : public BaseTest
                                SASEvent::HttpLogLevel::PROTOCOL,
                                _cm);
     fakecurl_responses.clear();
+    fakecurl_responses["http://3.0.0.0:80/http_success"] = "<message>success</message>";
+
+    fakecurl_responses["http://3.0.0.0:80/tcp_success"] = CURLE_REMOTE_FILE_NOT_FOUND;
+
+    fakecurl_responses["http://3.0.0.0:80/one_failure"] = CURLE_COULDNT_RESOLVE_HOST;
+    fakecurl_responses["http://3.0.0.1:80/one_failure"] = "<message>success</message>";
+
+    fakecurl_responses["http://3.0.0.0:80/all_failure"] = CURLE_COULDNT_RESOLVE_HOST;
+    fakecurl_responses["http://3.0.0.1:80/all_failure"] = CURLE_COULDNT_RESOLVE_HOST;
   }
 
   ~HttpConnectionBlacklistTest()
@@ -123,64 +148,71 @@ class HttpConnectionBlacklistTest : public BaseTest
     delete _cm; _cm = NULL;
     delete _am; _am = NULL;
   }
+
+  /// Creates a vector of count AddrInfo targets, beginning from 3.0.0.0 and
+  /// incrementing by one each time.
+  std::vector<AddrInfo> create_targets(int count)
+  {
+    std::vector<AddrInfo> targets;
+    AddrInfo ai;
+    ai.port = 80;
+    ai.transport = IPPROTO_TCP;
+    std::stringstream os;
+    for (int i = 0; i < count; ++i)
+    {
+      os << "3.0.0." << i;
+      BaseResolver::parse_ip_target(os.str(), ai.address);
+      targets.push_back(ai);
+      os.str(std::string());
+    }
+    return targets;
+  }
 };
 
-// Test that a success is reported to the resolver
 TEST_F(HttpConnectionBlacklistTest, BlacklistTestHttpSuccess)
 {
-  std::vector<AddrInfo> targets = MockHttpResolver::create_targets(2);
-  _resolver._targets = targets;
+  std::vector<AddrInfo> targets = create_targets(2);
 
-  fakecurl_responses["http://3.0.0.0:80/http_success"] = "<message>success</message>";
+  EXPECT_CALL(_resolver, resolve_iter(_,_,_)).
+    WillOnce(Return(new SimpleAddrIterator(targets)));
   EXPECT_CALL(_resolver, success(targets[0])).Times(1);
 
   string output;
   _http->send_get("/http_success", output, "", 0);
 }
 
-// Test that a success is reported to the resolver if the connection is
-// successful, but the request fails at the HTTP level
 TEST_F(HttpConnectionBlacklistTest, BlacklistTestTcpSuccess)
 {
-  std::vector<AddrInfo> targets = MockHttpResolver::create_targets(2);
-  _resolver._targets = targets;
+  std::vector<AddrInfo> targets = create_targets(2);
 
-  fakecurl_responses["http://3.0.0.0:80/tcp_success"] = CURLE_REMOTE_FILE_NOT_FOUND;
+  EXPECT_CALL(_resolver, resolve_iter(_,_,_)).
+    WillOnce(Return(new SimpleAddrIterator(targets)));
   EXPECT_CALL(_resolver, success(targets[0])).Times(1);
 
   string output;
   _http->send_get("/tcp_success", output, "", 0);
 }
 
-// Test that a single failure is reported to the resolver, and a following
-// success is also reported
 TEST_F(HttpConnectionBlacklistTest, BlacklistTestOneFailure)
 {
-  std::vector<AddrInfo> targets = MockHttpResolver::create_targets(2);
-  _resolver._targets = targets;
+  std::vector<AddrInfo> targets = create_targets(2);
 
-  // The first request should fail
-  fakecurl_responses["http://3.0.0.0:80/one_failure"] = CURLE_COULDNT_RESOLVE_HOST;
+  EXPECT_CALL(_resolver, resolve_iter(_,_,_)).
+    WillOnce(Return(new SimpleAddrIterator(targets)));
   EXPECT_CALL(_resolver, blacklist(targets[0])).Times(1);
-
-  // The second request should succeed
-  fakecurl_responses["http://3.0.0.1:80/one_failure"] = "<message>success</message>";
   EXPECT_CALL(_resolver, success(targets[1])).Times(1);
 
   string output;
   _http->send_get("/one_failure", output, "", 0);
 }
 
-// Test that multiple failures to connect are reported to the resolver
 TEST_F(HttpConnectionBlacklistTest, BlacklistTestAllFailure)
 {
-  std::vector<AddrInfo> targets = MockHttpResolver::create_targets(2);
-  _resolver._targets = targets;
+  std::vector<AddrInfo> targets = create_targets(2);
 
-  // Both requests should fail
-  fakecurl_responses["http://3.0.0.0:80/all_failure"] = CURLE_COULDNT_RESOLVE_HOST;
+  EXPECT_CALL(_resolver, resolve_iter(_,_,_)).
+    WillOnce(Return(new SimpleAddrIterator(targets)));
   EXPECT_CALL(_resolver, blacklist(targets[0])).Times(1);
-  fakecurl_responses["http://3.0.0.1:80/all_failure"] = CURLE_COULDNT_RESOLVE_HOST;
   EXPECT_CALL(_resolver, blacklist(targets[1])).Times(1);
 
   string output;
@@ -189,17 +221,13 @@ TEST_F(HttpConnectionBlacklistTest, BlacklistTestAllFailure)
 
 TEST_F(HttpConnectionTest, SimpleKeyAuthGet)
 {
-  _resolver._targets = MockHttpResolver::create_targets(1);
   string output;
-
-  fakecurl_responses["http://3.0.0.0:80/doc"] = "<?xml version=\"1.0\" encoding=\"UTF-8\"><boring>Document</boring>";
-
-  long ret = _http->send_get("/doc", output, "gandalf", 0);
+  long ret = _http->send_get("/blah/blah/blah", output, "gandalf", 0);
 
   EXPECT_EQ(200, ret);
   EXPECT_EQ("<?xml version=\"1.0\" encoding=\"UTF-8\"><boring>Document</boring>", output);
 
-  Request& req = fakecurl_requests["http://3.0.0.0:80/doc"];
+  Request& req = fakecurl_requests["http://10.42.42.42:80/blah/blah/blah"];
 
   EXPECT_EQ("GET", req._method);
   EXPECT_FALSE(req._httpauth & CURLAUTH_DIGEST) << req._httpauth;
@@ -227,50 +255,47 @@ TEST_F(HttpConnectionTest, GetWithHeadersAndUsername)
 
 TEST_F(HttpConnectionTest, SimpleIPv6Get)
 {
-  _resolver._targets.push_back(MockHttpResolver::create_target("1::1"));
   string output;
+  FakeHttpResolver _resolver("1::1");
+  HttpConnection http2("[1::1]:80",
+                       true,
+                       &_resolver,
+                       &SNMP::FAKE_IP_COUNT_TABLE,
+                       &_lm,
+                       SASEvent::HttpLogLevel::PROTOCOL,
+                       _cm);
 
   fakecurl_responses["http://[1::1]:80/ipv6get"] = CURLE_OK;
-
-  long ret = _http->send_get("/ipv6get", output, "gandalf", 0);
+  long ret = http2.send_get("/ipv6get", output, "gandalf", 0);
 
   EXPECT_EQ(200, ret);
 }
 
 TEST_F(HttpConnectionTest, SimpleGetFailure)
 {
-  _resolver._targets.push_back(MockHttpResolver::create_target("3.0.0.0"));
-
-  fakecurl_responses["http://3.0.0.0:80/file_not_found"] = CURLE_REMOTE_FILE_NOT_FOUND;
-  fakecurl_responses["http://3.0.0.0:80/503"] = 503;
+  EXPECT_CALL(*_cm, inform_failure(_)).Times(2);
 
   string output;
-  long ret = _http->send_get("/file_not_found", output, "gandalf", 0);
+  long ret = _http->send_get("/blah/blah/wot", output, "gandalf", 0);
 
   EXPECT_EQ(404, ret);
 
-  ret = _http->send_get("/503", output, "gandalf", 0);
+  ret = _http->send_get("/blah/blah/503", output, "gandalf", 0);
 
   EXPECT_EQ(503, ret);
 }
 
 TEST_F(HttpConnectionTest, SimpleGetRetry)
 {
-  _resolver._targets.push_back(MockHttpResolver::create_target("3.0.0.0"));
-
   string output;
 
   // Warm up the connection.
-  fakecurl_responses["http://3.0.0.0:80/warm"] = "<?xml version=\"1.0\" encoding=\"UTF-8\"><boring>Document</boring>";
-
-  long ret = _http->send_get("/warm", output, "gandalf", 0);
+  long ret = _http->send_get("/blah/blah/blah", output, "gandalf", 0);
 
   EXPECT_EQ(200, ret);
 
   // Get a failure on the connection and retry it.
-  fakecurl_responses["http://3.0.0.0:80/get_retry"] = Response(CURLE_SEND_ERROR, "<message>Gotcha!</message>");
-
-  ret = _http->send_get("/get_retry", output, "gandalf", 0);
+  ret = _http->send_get("/down/around", output, "gandalf", 0);
 
   EXPECT_EQ(200, ret);
   EXPECT_EQ("<message>Gotcha!</message>", output);
@@ -278,12 +303,8 @@ TEST_F(HttpConnectionTest, SimpleGetRetry)
 
 TEST_F(HttpConnectionTest, GetWithUsername)
 {
-  _resolver._targets.push_back(MockHttpResolver::create_target("3.0.0.0"));
-
   string output;
   std::map<std::string, std::string> headers_in_rsp;
-
-  fakecurl_responses["http://3.0.0.0:80/path"] = CURLE_OK;
 
   long ret = _http->send_get("/path", headers_in_rsp, output, "username", 0);
 
@@ -292,25 +313,18 @@ TEST_F(HttpConnectionTest, GetWithUsername)
 
 TEST_F(HttpConnectionTest, ReceiveError)
 {
-  _resolver._targets.push_back(MockHttpResolver::create_target("3.0.0.0"));
+  EXPECT_CALL(*_cm, inform_failure(_));
 
   string output;
-
-  fakecurl_responses["http://3.0.0.0:80/recv_error"] = CURLE_RECV_ERROR;
-
-  long ret = _http->send_get("/recv_error", output, "gandalf", 0);
+  long ret = _http->send_get("/blah/blah/recv_error", output, "gandalf", 0);
 
   EXPECT_EQ(500, ret);
 }
 
 TEST_F(HttpConnectionTest, SimplePost)
 {
-  _resolver._targets.push_back(MockHttpResolver::create_target("3.0.0.0"));
-
   std::map<std::string, std::string> head;
   std::string response;
-
-  fakecurl_responses["http://3.0.0.0:80/post_id"] = Response({"Location: test"});
 
   long ret = _http->send_post("/post_id", head, response, "", 0);
 
@@ -319,9 +333,7 @@ TEST_F(HttpConnectionTest, SimplePost)
 
 TEST_F(HttpConnectionTest, SimplePut)
 {
-  _resolver._targets.push_back(MockHttpResolver::create_target("3.0.0.0"));
-
-  fakecurl_responses["http://3.0.0.0:80/put_id"] = Response({"response"});
+  EXPECT_CALL(*_cm, inform_success(_));
 
   long ret = _http->send_put("/put_id", "", 0);
 
@@ -330,12 +342,9 @@ TEST_F(HttpConnectionTest, SimplePut)
 
 TEST_F(HttpConnectionTest, SimplePutWithResponse)
 {
-  _resolver._targets.push_back(MockHttpResolver::create_target("3.0.0.0"));
+  EXPECT_CALL(*_cm, inform_success(_));
 
   std::string response;
-
-  fakecurl_responses["http://3.0.0.0:80/put_id_response"] = Response({"response"});
-
   long ret = _http->send_put("/put_id_response", response, "", 0);
 
   EXPECT_EQ(200, ret);
@@ -357,10 +366,6 @@ TEST_F(HttpConnectionTest, PutWithHeadersAndUsername)
 
 TEST_F(HttpConnectionTest, SimpleDelete)
 {
-  _resolver._targets.push_back(MockHttpResolver::create_target("3.0.0.0"));
-
-  fakecurl_responses["http://3.0.0.0:80/delete_id"] = CURLE_OK;
-
   long ret = _http->send_delete("/delete_id", 0);
 
   EXPECT_EQ(200, ret);
@@ -368,10 +373,6 @@ TEST_F(HttpConnectionTest, SimpleDelete)
 
 TEST_F(HttpConnectionTest, DeleteBody)
 {
-  _resolver._targets.push_back(MockHttpResolver::create_target("3.0.0.0"));
-
-  fakecurl_responses["http://3.0.0.0:80/delete_id"] = CURLE_OK;
-
   long ret = _http->send_delete("/delete_id", 0, "body");
 
   EXPECT_EQ(200, ret);
@@ -379,12 +380,7 @@ TEST_F(HttpConnectionTest, DeleteBody)
 
 TEST_F(HttpConnectionTest, DeleteBodyWithResponse)
 {
-  _resolver._targets.push_back(MockHttpResolver::create_target("3.0.0.0"));
-
   std::string response;
-
-  fakecurl_responses["http://3.0.0.0:80/delete_id"] = CURLE_OK;
-
   long ret = _http->send_delete("/delete_id", 0, "body", response);
 
   EXPECT_EQ(200, ret);
@@ -401,18 +397,14 @@ TEST_F(HttpConnectionTest, DeleteBodyWithHeadersAndUsername)
 
 TEST_F(HttpConnectionTest, SASCorrelationHeader)
 {
-  _resolver._targets.push_back(MockHttpResolver::create_target("3.0.0.0"));
-
   mock_sas_collect_messages(true);
 
   std::string uuid;
   std::string output;
 
-  fakecurl_responses["http://3.0.0.0:80/doc"] = "<?xml version=\"1.0\" encoding=\"UTF-8\"><boring>Document</boring>";
+  _http->send_get("/blah/blah/blah", output, "gandalf", 0);
 
-  _http->send_get("/doc", output, "gandalf", 0);
-
-  Request& req = fakecurl_requests["http://3.0.0.0:80/doc"];
+  Request& req = fakecurl_requests["http://10.42.42.42:80/blah/blah/blah"];
 
   // The CURL request should contain an X-SAS-HTTP-Branch-ID whose value is a
   // UUID.
@@ -450,8 +442,6 @@ TEST_F(HttpConnectionTest, SASCorrelationHeader)
 
 TEST_F(HttpConnectionTest, ParseHostPort)
 {
-  _resolver._targets.push_back(MockHttpResolver::create_target("3.0.0.0"));
-
   // Test port-parsing by adding a port
   HttpConnection http2("cyrus:1234",
                        true,
@@ -460,10 +450,9 @@ TEST_F(HttpConnectionTest, ParseHostPort)
                        &_lm,
                        SASEvent::HttpLogLevel::PROTOCOL,
                        _cm);
-  fakecurl_responses["http://3.0.0.0:1234/port-1234"] = "<?xml version=\"1.0\" encoding=\"UTF-8\"><boring>Document</boring>";
+  fakecurl_responses["http://10.42.42.42:1234/port-1234"] = "<?xml version=\"1.0\" encoding=\"UTF-8\"><boring>Document</boring>";
 
   string output;
-
   long ret = http2.send_get("/port-1234", output, "gandalf", 0);
 
   EXPECT_EQ(200, ret);
@@ -472,8 +461,6 @@ TEST_F(HttpConnectionTest, ParseHostPort)
 
 TEST_F(HttpConnectionTest, ParseHostPortIPv6)
 {
-  _resolver._targets.push_back(MockHttpResolver::create_target("3.0.0.0"));
-
   // Test parsing with an IPv6 address
   HttpConnection http2("[1::1]",
                        true,
@@ -484,10 +471,7 @@ TEST_F(HttpConnectionTest, ParseHostPortIPv6)
                        _cm);
 
   string output;
-
-  fakecurl_responses["http://3.0.0.0:80/doc"] = "<?xml version=\"1.0\" encoding=\"UTF-8\"><boring>Document</boring>";
-
-  long ret = http2.send_get("/doc", output, "gandalf", 0);
+  long ret = http2.send_get("/blah/blah/blah", output, "gandalf", 0);
 
   EXPECT_EQ(200, ret);
   EXPECT_EQ("<?xml version=\"1.0\" encoding=\"UTF-8\"><boring>Document</boring>", output);

--- a/src/ut/httpconnection_test.cpp
+++ b/src/ut/httpconnection_test.cpp
@@ -54,7 +54,6 @@
 #include "curl_interposer.hpp"
 #include "fakecurl.hpp"
 #include "test_interposer.hpp"
-#include "fake_iterator.h"
 
 using namespace std;
 using ::testing::MatchesRegex;

--- a/src/ut/httpconnection_test.cpp
+++ b/src/ut/httpconnection_test.cpp
@@ -42,8 +42,8 @@
 
 #include "utils.h"
 #include "sas.h"
-#include "mock_http_resolver.h"
 #include "fakehttpresolver.hpp"
+#include "mock_http_resolver.h"
 #include "httpconnection.h"
 #include "basetest.hpp"
 #include "test_utils.hpp"
@@ -65,14 +65,13 @@ using ::testing::StrictMock;
 // Fixture for tests using fake resolver
 class HttpConnectionTest : public BaseTest
 {
-  FakeHttpResolver _resolver;
-  HttpConnection* _http;
   LoadMonitor _lm;
+  FakeHttpResolver _resolver;
   AlarmManager* _am = new AlarmManager();
   NiceMock<MockCommunicationMonitor>*_cm = new NiceMock<MockCommunicationMonitor>(_am);
+  HttpConnection* _http;
 
   HttpConnectionTest() :
-    _resolver(),
     _lm(100000, 20, 10, 10)
   {
     _http = new HttpConnection("cyrus",
@@ -85,7 +84,7 @@ class HttpConnectionTest : public BaseTest
     fakecurl_responses.clear();
   }
 
-  ~HttpConnectionTest()
+  virtual ~HttpConnectionTest()
   {
     fakecurl_responses.clear();
     fakecurl_requests.clear();
@@ -98,14 +97,13 @@ class HttpConnectionTest : public BaseTest
 // Fixture for blacklist tests using mock resolver
 class HttpConnectionBlacklistTest : public BaseTest
 {
-  MockHttpResolver _resolver;
+  StrictMock<MockHttpResolver> _resolver;
   HttpConnection* _http;
   LoadMonitor _lm;
   AlarmManager* _am = new AlarmManager();
   NiceMock<MockCommunicationMonitor>*_cm = new NiceMock<MockCommunicationMonitor>(_am);
 
   HttpConnectionBlacklistTest() :
-    _resolver(),
     _lm(100000, 20, 10, 10)
   {
     _http = new HttpConnection("cyrus",

--- a/src/ut/httpconnection_test.cpp
+++ b/src/ut/httpconnection_test.cpp
@@ -43,7 +43,7 @@
 #include "utils.h"
 #include "sas.h"
 #include "fakehttpresolver.hpp"
-#include "mock_http_resolver.h"
+#include "mockhttpresolver.h"
 #include "httpconnection.h"
 #include "basetest.hpp"
 #include "test_utils.hpp"

--- a/src/ut/resolver_test.h
+++ b/src/ut/resolver_test.h
@@ -63,7 +63,7 @@ public:
   virtual std::vector<AddrInfo> resolve(int max_targets) = 0;
 
   /// Creates and returns an AddrInfo object with the given data.
-  AddrInfo ip_to_addr_info(std::string address_str,
+  static AddrInfo ip_to_addr_info(std::string address_str,
                            int port = TEST_PORT,
                            int transport = TEST_TRANSPORT);
 


### PR DESCRIPTION
Add unit tests, and modify existing unit tests, for HTTP lazy targeting in cpp-common pull request [#549](https://github.com/Metaswitch/cpp-common/pull/549).
