### PR TITLE
[Reviewer:EM] Test bracket functions in cpp-common

### DIFF
--- a/src/ut/utils_test.cpp
+++ b/src/ut/utils_test.cpp
@@ -112,3 +112,43 @@ TEST_F(UtilsTest, InvalidAddress)
 {
   EXPECT_EQ(IPAddressType::INVALID, parse_ip_address("327.0.0.1"));
 }
+
+TEST_F(UtilsTest, UriServerForIpV4WithDefaultPort)
+{
+  EXPECT_EQ("127.0.0.1:80", uri_ip_address("127.0.0.1:80", 80));
+}
+
+TEST_F(UtilsTest, UriServerForIpV4WithSpecifiedPort)
+{
+  EXPECT_EQ("127.0.0.1:81", uri_ip_address("127.0.0.1:81", 80));
+}
+
+TEST_F(UtilsTest, UriServerForIpV6WithDefaultPort)
+{
+  EXPECT_EQ("[::1]:80", uri_ip_address("::1", 80));
+}
+
+TEST_F(UtilsTest, UriServerForIpV6BracketedWithDefaultPort)
+{
+  EXPECT_EQ("[::1]:80", uri_ip_address("[::1]", 80));
+}
+
+TEST_F(UtilsTest, UriServerForIpV6WithSpecifiedPort)
+{
+  EXPECT_EQ("[::1]:81", uri_ip_address("[::1]:81", 80));
+}
+
+TEST_F(UtilsTest, RemoveBracketsFromIPv4Address)
+{
+  EXPECT_EQ("127.0.0.1", remove_brackets_from_ip("127.0.0.1"));
+}
+
+TEST_F(UtilsTest, RemoveBracketsFromBracketedIPv6Address)
+{
+  EXPECT_EQ("::1", remove_brackets_from_ip("[::1]"));
+}
+
+TEST_F(UtilsTest, RemoveBracketsFromBareIPv6Address)
+{
+  EXPECT_EQ("::1", remove_brackets_from_ip("::1"));
+}

--- a/src/ut/utils_test.cpp
+++ b/src/ut/utils_test.cpp
@@ -113,29 +113,49 @@ TEST_F(UtilsTest, InvalidAddress)
   EXPECT_EQ(IPAddressType::INVALID, parse_ip_address("327.0.0.1"));
 }
 
+TEST_F(UtilsTest, IsBracketedAddressNo)
+{
+  EXPECT_FALSE(is_bracketed_address("::1"));
+}
+
+TEST_F(UtilsTest, IsBracketedAddressYes)
+{
+  EXPECT_TRUE(is_bracketed_address("[::1]"));
+}
+
 TEST_F(UtilsTest, UriServerForIpV4WithDefaultPort)
 {
-  EXPECT_EQ("127.0.0.1:80", uri_ip_address("127.0.0.1:80", 80));
+  EXPECT_EQ("127.0.0.1:80", uri_address("127.0.0.1:80", 80));
 }
 
 TEST_F(UtilsTest, UriServerForIpV4WithSpecifiedPort)
 {
-  EXPECT_EQ("127.0.0.1:81", uri_ip_address("127.0.0.1:81", 80));
+  EXPECT_EQ("127.0.0.1:81", uri_address("127.0.0.1:81", 80));
 }
 
 TEST_F(UtilsTest, UriServerForIpV6WithDefaultPort)
 {
-  EXPECT_EQ("[::1]:80", uri_ip_address("::1", 80));
+  EXPECT_EQ("[::1]:80", uri_address("::1", 80));
 }
 
 TEST_F(UtilsTest, UriServerForIpV6BracketedWithDefaultPort)
 {
-  EXPECT_EQ("[::1]:80", uri_ip_address("[::1]", 80));
+  EXPECT_EQ("[::1]:80", uri_address("[::1]", 80));
 }
 
 TEST_F(UtilsTest, UriServerForIpV6WithSpecifiedPort)
 {
-  EXPECT_EQ("[::1]:81", uri_ip_address("[::1]:81", 80));
+  EXPECT_EQ("[::1]:81", uri_address("[::1]:81", 80));
+}
+
+TEST_F(UtilsTest, UriServerForHost)
+{
+  EXPECT_EQ("example.com:80", uri_address("example.com", 80));
+}
+
+TEST_F(UtilsTest, UriServerForHostWithPort)
+{
+  EXPECT_EQ("example.com:81", uri_address("example.com:81", 80));
 }
 
 TEST_F(UtilsTest, RemoveBracketsFromIPv4Address)


### PR DESCRIPTION
Ellie,

This adds the tests for https://github.com/Metaswitch/cpp-common/pull/555 which adds functions for bracketing IPv6 addresses, and removing the brackets.
