### PR TITLE
[Reviewer: Ellie] UTs for static DNS records

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -107,6 +107,8 @@ cpp_common_test_test_LDFLAGS := -L../usr/lib \
                                 -ldl \
                                 -lpthread \
                                 -lboost_regex \
+                                -lboost_thread \
+                                -lboost_system \
                                 -lzmq \
                                 -lcares \
                                 -levhtp \

--- a/src/Makefile
+++ b/src/Makefile
@@ -75,6 +75,7 @@ cpp_common_test_test_SOURCES := accesslogger.cpp \
                                 chronosconnection_test.cpp \
                                 communicationmonitor_test.cpp \
                                 connection_pool_test.cpp \
+                                dnscachedresolver_test.cpp \
                                 diameterresolver_test.cpp \
                                 diameterstack_test.cpp \
                                 httpclient_test.cpp \

--- a/src/Makefile
+++ b/src/Makefile
@@ -107,8 +107,6 @@ cpp_common_test_test_LDFLAGS := -L../usr/lib \
                                 -ldl \
                                 -lpthread \
                                 -lboost_regex \
-                                -lboost_thread \
-                                -lboost_system \
                                 -lzmq \
                                 -lcares \
                                 -levhtp \

--- a/src/ut/bad_rrtype_dns_config.json
+++ b/src/ut/bad_rrtype_dns_config.json
@@ -1,0 +1,16 @@
+{
+  "one.redirected.domain": [
+    {
+      "target": "a.different.target"
+    },
+    {
+      "rrtype": "A",
+      "target": "10.10.10.10"
+    },
+    {
+      "rrtype": "CNAME",
+      "target": "one.made.up.domain"
+    }
+  ]
+}
+

--- a/src/ut/bad_rrtype_dns_config.json
+++ b/src/ut/bad_rrtype_dns_config.json
@@ -1,15 +1,20 @@
 {
-  "one.redirected.domain": [
+  "hostnames": [
     {
-      "target": "a.different.target"
-    },
-    {
-      "rrtype": "A",
-      "target": "10.10.10.10"
-    },
-    {
-      "rrtype": "CNAME",
-      "target": "one.made.up.domain"
+      "name": "one.redirected.domain",
+      "records": [
+        {
+          "target": "one.made.up.domain"
+        },
+        {
+          "rrtype": "A",
+          "target": "10.10.10.10"
+        },
+        {
+          "rrtype": "CNAME",
+          "target": "one.made.up.domain"
+        }
+      ]
     }
   ]
 }

--- a/src/ut/dnscachedresolver_test.cpp
+++ b/src/ut/dnscachedresolver_test.cpp
@@ -182,3 +182,18 @@ TEST_F(DnsCachedResolverTest, DuplicateJson)
   EXPECT_EQ(result.domain(), "one.made.up.domain");
   EXPECT_EQ(result.records().size(), 1);
 }
+
+TEST_F(DnsCachedResolverTest, JsonBadRrtype)
+{
+  TestDnsCachedResolver resolver(string(UT_DIR).append("/bad_rrtype_dns_config.json"));
+  resolver.add_fake_entries_to_cache();
+
+  DnsResult result = resolver.dns_query("one.redirected.domain", ns_t_a, 0);
+
+  // The first entry with a missing "rrtype" member and the A record should have
+  // been skipped, but the valid CNAME record should have been read in
+  EXPECT_EQ(resolver.static_records().size(), 1);
+  EXPECT_EQ(resolver.static_records().at("one.redirected.domain").size(), 1);
+  EXPECT_EQ(result.domain(), "one.made.up.domain");
+  EXPECT_EQ(result.records().size(), 1);
+}

--- a/src/ut/dnscachedresolver_test.cpp
+++ b/src/ut/dnscachedresolver_test.cpp
@@ -49,6 +49,8 @@ class TestDnsCachedResolver : public  DnsCachedResolver
   TestDnsCachedResolver(string filename) :
     DnsCachedResolver({"0.0.0.0"}, filename)
   {
+    reload_static_records();
+    add_fake_entries_to_cache();
   }
 
   // Adds some A records to the cache
@@ -97,7 +99,6 @@ public:
 TEST_F(DnsCachedResolverTest, SingleRecordLookup)
 {
   TestDnsCachedResolver resolver("");
-  resolver.add_fake_entries_to_cache();
 
   string domain = "one.made.up.domain";
   DnsResult result = resolver.dns_query(domain, ns_t_a, 0);
@@ -109,7 +110,6 @@ TEST_F(DnsCachedResolverTest, SingleRecordLookup)
 TEST_F(DnsCachedResolverTest, NoRecordLookup)
 {
   TestDnsCachedResolver resolver("");
-  resolver.add_fake_entries_to_cache();
 
   string domain = "nonexistent.made.up.domain";
   DnsResult result = resolver.dns_query(domain, ns_t_a, 0);
@@ -121,7 +121,6 @@ TEST_F(DnsCachedResolverTest, NoRecordLookup)
 TEST_F(DnsCachedResolverTest, MissingJson)
 {
   TestDnsCachedResolver resolver(string(UT_DIR).append("/nonexistent_file.json"));
-  resolver.add_fake_entries_to_cache();
 
   EXPECT_EQ(resolver.static_records().size(), 0);
 }
@@ -129,7 +128,6 @@ TEST_F(DnsCachedResolverTest, MissingJson)
 TEST_F(DnsCachedResolverTest, ValidJson)
 {
   TestDnsCachedResolver resolver(string(UT_DIR).append("/valid_dns_config.json"));
-  resolver.add_fake_entries_to_cache();
 
   EXPECT_EQ(resolver.static_records().size(), 3);
 }
@@ -137,7 +135,6 @@ TEST_F(DnsCachedResolverTest, ValidJson)
 TEST_F(DnsCachedResolverTest, InvalidJson)
 {
   TestDnsCachedResolver resolver(string(UT_DIR).append("/invalid_dns_config.json"));
-  resolver.add_fake_entries_to_cache();
 
   EXPECT_EQ(resolver.static_records().size(), 0);
 }
@@ -145,7 +142,6 @@ TEST_F(DnsCachedResolverTest, InvalidJson)
 TEST_F(DnsCachedResolverTest, ValidJsonRedirectedLookup)
 {
   TestDnsCachedResolver resolver(string(UT_DIR).append("/valid_dns_config.json"));
-  resolver.add_fake_entries_to_cache();
 
   DnsResult result = resolver.dns_query("one.extra.domain", ns_t_a, 0);
 
@@ -158,7 +154,6 @@ TEST_F(DnsCachedResolverTest, ValidJsonRedirectedLookup)
 TEST_F(DnsCachedResolverTest, ValidJsonRedirectedLookupNoResult)
 {
   TestDnsCachedResolver resolver(string(UT_DIR).append("/valid_dns_config.json"));
-  resolver.add_fake_entries_to_cache();
 
   DnsResult result = resolver.dns_query("three.extra.domain", ns_t_a, 0);
 
@@ -171,7 +166,6 @@ TEST_F(DnsCachedResolverTest, ValidJsonRedirectedLookupNoResult)
 TEST_F(DnsCachedResolverTest, DuplicateJson)
 {
   TestDnsCachedResolver resolver(string(UT_DIR).append("/duplicate_dns_config.json"));
-  resolver.add_fake_entries_to_cache();
 
   DnsResult result = resolver.dns_query("one.duplicated.domain", ns_t_a, 0);
 
@@ -186,7 +180,6 @@ TEST_F(DnsCachedResolverTest, DuplicateJson)
 TEST_F(DnsCachedResolverTest, JsonBadRrtype)
 {
   TestDnsCachedResolver resolver(string(UT_DIR).append("/bad_rrtype_dns_config.json"));
-  resolver.add_fake_entries_to_cache();
 
   DnsResult result = resolver.dns_query("one.redirected.domain", ns_t_a, 0);
 

--- a/src/ut/dnscachedresolver_test.cpp
+++ b/src/ut/dnscachedresolver_test.cpp
@@ -1,0 +1,184 @@
+/**
+ * @file dnscachedresolver_test.cpp UT for DnsCachedResolver class.
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2016  Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed under the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "test_interposer.hpp"
+#include "test_utils.hpp"
+#include "dnscachedresolver.h"
+
+using namespace std;
+
+// We don't test the DnsCachedResolver directly as we want to be able to
+// manually add entries to the DnsCache
+class TestDnsCachedResolver : public  DnsCachedResolver
+{
+  TestDnsCachedResolver(string filename) :
+    DnsCachedResolver({"0.0.0.0"}, filename)
+  {
+  }
+
+  // Adds some A records to the cache
+  void add_fake_entries_to_cache()
+  {
+    vector<string> domains = {"one.made.up.domain", "two.made.up.domain"};
+
+    time_t expiry = time(NULL) + 1;
+
+    for (vector<string>::const_iterator domain = domains.begin();
+         domain != domains.end();
+         ++domain)
+    {
+      DnsCacheEntryPtr ce = create_cache_entry(*domain, ns_t_a);
+      ce->expires = expiry;
+
+      struct in_addr address;
+      DnsARecord* record = new DnsARecord(*domain, 1000, address);
+      add_record_to_cache(ce, record);
+    }
+  }
+
+  map<string, vector<DnsRRecord*>> static_records()
+  {
+    return _static_records;
+  }
+};
+
+class DnsCachedResolverTest : public ::testing::Test
+{
+public:
+  DnsCachedResolverTest() :
+    _resolver("")
+  {
+    cwtest_completely_control_time();
+  }
+
+  ~DnsCachedResolverTest()
+  {
+    cwtest_reset_time();
+  }
+
+  TestDnsCachedResolver _resolver;
+};
+
+TEST_F(DnsCachedResolverTest, SingleRecordLookup)
+{
+  TestDnsCachedResolver resolver("");
+  resolver.add_fake_entries_to_cache();
+
+  string domain = "one.made.up.domain";
+  DnsResult result = resolver.dns_query(domain, ns_t_a, 0);
+
+  EXPECT_EQ(result.domain(), domain);
+  EXPECT_EQ(result.records().size(), 1);
+}
+
+TEST_F(DnsCachedResolverTest, NoRecordLookup)
+{
+  TestDnsCachedResolver resolver("");
+  resolver.add_fake_entries_to_cache();
+
+  string domain = "nonexistent.made.up.domain";
+  DnsResult result = resolver.dns_query(domain, ns_t_a, 0);
+
+  EXPECT_EQ(result.domain(), domain);
+  EXPECT_EQ(result.records().size(), 0);
+}
+
+TEST_F(DnsCachedResolverTest, MissingJson)
+{
+  TestDnsCachedResolver resolver(string(UT_DIR).append("/nonexistent_file.json"));
+  resolver.add_fake_entries_to_cache();
+
+  EXPECT_EQ(resolver.static_records().size(), 0);
+}
+
+TEST_F(DnsCachedResolverTest, ValidJson)
+{
+  TestDnsCachedResolver resolver(string(UT_DIR).append("/valid_dns_config.json"));
+  resolver.add_fake_entries_to_cache();
+
+  EXPECT_EQ(resolver.static_records().size(), 3);
+}
+
+TEST_F(DnsCachedResolverTest, InvalidJson)
+{
+  TestDnsCachedResolver resolver(string(UT_DIR).append("/invalid_dns_config.json"));
+  resolver.add_fake_entries_to_cache();
+
+  EXPECT_EQ(resolver.static_records().size(), 0);
+}
+
+TEST_F(DnsCachedResolverTest, ValidJsonRedirectedLookup)
+{
+  TestDnsCachedResolver resolver(string(UT_DIR).append("/valid_dns_config.json"));
+  resolver.add_fake_entries_to_cache();
+
+  DnsResult result = resolver.dns_query("one.extra.domain", ns_t_a, 0);
+
+  // The lookup should have been redirected by the static CNAME record in the json
+  // and retrieved one result record.
+  EXPECT_EQ(result.domain(), "one.made.up.domain");
+  EXPECT_EQ(result.records().size(), 1);
+}
+
+TEST_F(DnsCachedResolverTest, ValidJsonRedirectedLookupNoResult)
+{
+  TestDnsCachedResolver resolver(string(UT_DIR).append("/valid_dns_config.json"));
+  resolver.add_fake_entries_to_cache();
+
+  DnsResult result = resolver.dns_query("three.extra.domain", ns_t_a, 0);
+
+  // The lookup should have been redirected by the static CNAME record in the json
+  // but there should be no results
+  EXPECT_EQ(result.domain(), "three.made.up.domain");
+  EXPECT_EQ(result.records().size(), 0);
+}
+
+TEST_F(DnsCachedResolverTest, DuplicateJson)
+{
+  TestDnsCachedResolver resolver(string(UT_DIR).append("/duplicate_dns_config.json"));
+  resolver.add_fake_entries_to_cache();
+
+  DnsResult result = resolver.dns_query("one.duplicated.domain", ns_t_a, 0);
+
+  // Only the first of the two duplicates should have been read in, and that
+  // should be used for the redirection
+  EXPECT_EQ(resolver.static_records().size(), 1);
+  EXPECT_EQ(resolver.static_records().at("one.duplicated.domain").size(), 1);
+  EXPECT_EQ(result.domain(), "one.made.up.domain");
+  EXPECT_EQ(result.records().size(), 1);
+}

--- a/src/ut/duplicate_dns_config.json
+++ b/src/ut/duplicate_dns_config.json
@@ -1,0 +1,19 @@
+{
+  "one.duplicated.domain": [
+    {
+      "rrtype": "CNAME",
+      "target": "one.made.up.domain"
+    },
+    {
+      "rrtype": "CNAME",
+      "target": "two.made.up.domain"
+    }
+  ],
+  "one.duplicated.domain": [
+    {
+      "rrtype": "CNAME",
+      "target": "three.made.up.domain"
+    }
+  ]
+}
+

--- a/src/ut/duplicate_dns_config.json
+++ b/src/ut/duplicate_dns_config.json
@@ -1,18 +1,26 @@
 {
-  "one.duplicated.domain": [
+  "hostnames": [
     {
-      "rrtype": "CNAME",
-      "target": "one.made.up.domain"
+      "name": "one.duplicated.domain",
+      "records": [
+        {
+          "rrtype": "CNAME",
+          "target": "one.made.up.domain"
+        },
+        {
+          "rrtype": "CNAME",
+          "target": "two.made.up.domain"
+        }
+      ]
     },
     {
-      "rrtype": "CNAME",
-      "target": "two.made.up.domain"
-    }
-  ],
-  "one.duplicated.domain": [
-    {
-      "rrtype": "CNAME",
-      "target": "three.made.up.domain"
+      "name": "one.duplicated.domain",
+      "records": [
+        {
+          "rrtype": "CNAME",
+          "target": "three.made.up.domain"
+        }
+      ]
     }
   ]
 }

--- a/src/ut/invalid_dns_config.json
+++ b/src/ut/invalid_dns_config.json
@@ -1,15 +1,14 @@
 {
-  "one.extra.domain": [
+  "hostnames": [
     {
-      "rrtype": "CNAME",
-      "target": "one.made.up.domain"
+      "name": "one.extra.domain",
+      "records": [
+        {
+          "rrtype": "CNAME",
+          "target": "one.made.up.domain"
+        }
+      ]
     }
-  ],
-  "two.extra.domain": [
-    {
-      "rrtype": "CNAME",
-      "target": "two.made.up.domain"
-    }
-THIS IS NOT VALID JSON
+INVALID JSON
+  ]
 }
-

--- a/src/ut/invalid_dns_config.json
+++ b/src/ut/invalid_dns_config.json
@@ -1,0 +1,15 @@
+{
+  "one.extra.domain": [
+    {
+      "rrtype": "CNAME",
+      "target": "one.made.up.domain"
+    }
+  ],
+  "two.extra.domain": [
+    {
+      "rrtype": "CNAME",
+      "target": "two.made.up.domain"
+    }
+THIS IS NOT VALID JSON
+}
+

--- a/src/ut/valid_dns_config.json
+++ b/src/ut/valid_dns_config.json
@@ -1,0 +1,21 @@
+{
+  "one.extra.domain": [
+    {
+      "rrtype": "CNAME",
+      "target": "one.made.up.domain"
+    }
+  ],
+  "two.extra.domain": [
+    {
+      "rrtype": "CNAME",
+      "target": "two.made.up.domain"
+    }
+  ],
+  "three.extra.domain": [
+    {
+      "rrtype": "CNAME",
+      "target": "three.made.up.domain"
+    }
+  ]
+}
+

--- a/src/ut/valid_dns_config.json
+++ b/src/ut/valid_dns_config.json
@@ -1,20 +1,31 @@
 {
-  "one.extra.domain": [
+  "hostnames": [
     {
-      "rrtype": "CNAME",
-      "target": "one.made.up.domain"
-    }
-  ],
-  "two.extra.domain": [
+      "name": "one.extra.domain",
+      "records": [
+        {
+          "rrtype": "CNAME",
+          "target": "one.made.up.domain"
+        }
+      ]
+    },
     {
-      "rrtype": "CNAME",
-      "target": "two.made.up.domain"
-    }
-  ],
-  "three.extra.domain": [
+      "name": "two.extra.domain",
+      "records": [
+        {
+          "rrtype": "CNAME",
+          "target": "two.made.up.domain"
+        }
+      ]
+    },
     {
-      "rrtype": "CNAME",
-      "target": "three.made.up.domain"
+      "name": "three.extra.domain",
+      "records": [
+        {
+          "rrtype": "CNAME",
+          "target": "three.made.up.domain"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
DnsCachedResolver can now read in static DNS records from a JSON file. This
commit adds UTs for this.
