### PR TITLE
[Reviewer: Krista] Control time now we check explicit values

### DIFF
--- a/src/ut/diameterresolver_test.cpp
+++ b/src/ut/diameterresolver_test.cpp
@@ -43,6 +43,7 @@
 #include "diameterresolver.h"
 #include "test_utils.hpp"
 #include "resolver_utils.h"
+#include "test_interposer.hpp"
 
 using namespace std;
 
@@ -58,10 +59,12 @@ class DiameterResolverTest : public ::testing::Test
     _dnsresolver("0.0.0.0"),
     _diameterresolver(&_dnsresolver, AF_INET)
   {
+    cwtest_completely_control_time();
   }
 
   virtual ~DiameterResolverTest()
   {
+    cwtest_reset_time();
   }
 };
 


### PR DESCRIPTION
This controls the time in the DiameterResolver tests (now that we check explicit values for TTLs).

Tested in UTs by adding sleeps to various resolve functions, and checking the tests failed without the fixes, and passed with.