### PR TITLE
[Reviewer: HJS] UT changes for 'allowed_host_state' interface change and implementation

### DIFF
--- a/src/ut/baseresolver_test.cpp
+++ b/src/ut/baseresolver_test.cpp
@@ -122,30 +122,6 @@ class BaseResolverTest : public ResolverTest
   }
 };
 
-// Test that allowed host states function returns the correct bools.
-TEST_F(BaseResolverTest, GetAllowedHostStates)
-{
-  int allowed_host_state = BaseResolver::ALL_LISTS;
-  bool whitelisted_allowed, blacklisted_allowed;
-
-  _baseresolver.get_allowed_host_states(
-                allowed_host_state, whitelisted_allowed, blacklisted_allowed);
-  EXPECT_TRUE(whitelisted_allowed);
-  EXPECT_TRUE(blacklisted_allowed);
-
-  allowed_host_state = BaseResolver::WHITELISTED;
-  _baseresolver.get_allowed_host_states(
-                allowed_host_state, whitelisted_allowed, blacklisted_allowed);
-  EXPECT_TRUE(whitelisted_allowed);
-  EXPECT_FALSE(blacklisted_allowed);
-
-  allowed_host_state = BaseResolver::BLACKLISTED;
-  _baseresolver.get_allowed_host_states(
-                allowed_host_state, whitelisted_allowed, blacklisted_allowed);
-  EXPECT_FALSE(whitelisted_allowed);
-  EXPECT_TRUE(blacklisted_allowed);
-}
-
 // Test that basic parsing of IP addresses works
 TEST_F(BaseResolverTest, ParseIPAddresses)
 {

--- a/src/ut/baseresolver_test.cpp
+++ b/src/ut/baseresolver_test.cpp
@@ -82,22 +82,6 @@ class BaseResolverTest : public ResolverTest
                                         TEST_TRANSPORT, ttl, 1, allowed_host_state);
   }
 
-  /// Calls srv resolve and renders the result as a string
-  //std::string srv_resolve(std::string realm)
-  //{
-  //  std::vector<AddrInfo> targets;
-  //  int ttl = 0;
-  //  std::string output;
-//
-  //  _baseresolver.srv_resolve(
-  //    realm, AF_INET, IPPROTO_SCTP, 2, targets, ttl, 1, BaseResolver::ALL_LISTS);
-  //  if (!targets.empty())
-  //  {
-  //    output = ResolverUtils::addrinfo_to_string(targets[0]);
-  //  }
-  //  return output;
-  //}
-
   // Calls srv resolve and renders the result as a vector
   std::vector<AddrInfo> srv_resolve(std::string realm,
                                     int retries=2,
@@ -112,6 +96,8 @@ class BaseResolverTest : public ResolverTest
     return targets;
   }
 
+  // Calls srv resolve, returning the first result as a string (if there is
+  // a result)
   std::string first_result_from_srv(std::string realm)
   {
     std::vector<AddrInfo> targets = srv_resolve(realm);

--- a/src/ut/baseresolver_test.cpp
+++ b/src/ut/baseresolver_test.cpp
@@ -95,7 +95,7 @@ class BaseResolverTest : public ResolverTest
   std::string srv_resolve(std::string realm)
   {
     std::vector<AddrInfo> targets;
-    int ttl;
+    int ttl = 0;
     std::string output;
 
     _baseresolver.srv_resolve(
@@ -113,7 +113,7 @@ class BaseResolverTest : public ResolverTest
                                     int allowed_host_state)
   {
     std::vector<AddrInfo> targets;
-    int ttl;
+    int ttl = 0;
 
     _baseresolver.srv_resolve(
       realm, AF_INET, IPPROTO_SCTP, retries, targets, ttl, 1, allowed_host_state);

--- a/src/ut/httpresolver_test.cpp
+++ b/src/ut/httpresolver_test.cpp
@@ -46,7 +46,8 @@ class HttpResolverTest : public ResolverTest
     return targets;
   }
 
-  std::vector<AddrInfo> resolve(int max_targets)
+  std::vector<AddrInfo> resolve(
+              int max_targets, int allowed_host_state=BaseResolver::ALL_LISTS)
   {
     return resolve(max_targets, TEST_HOST, TEST_PORT);
   }

--- a/src/ut/resolver_test.h
+++ b/src/ut/resolver_test.h
@@ -35,7 +35,8 @@ public:
 
   /// Pure virtual method - subclasses define how they interact with the
   /// resolver under test.
-  virtual std::vector<AddrInfo> resolve(int max_targets) = 0;
+  virtual std::vector<AddrInfo> resolve(
+          int max_targets, int allowed_host_state=BaseResolver::ALL_LISTS) = 0;
 
   /// Creates and returns an AddrInfo object with the given data.
   static AddrInfo ip_to_addr_info(std::string address_str,


### PR DESCRIPTION
Accompanies Metaswitch/cpp-common-test#661.

This adds 3 new tests:

* Check that the `get_allowed_host_states` helper function sets the bool values correctly,
* Check the host state implementation for A-record resolution,
* Check the host state implementation for SRV-record resolution.

Potentially contentious points:

* I overloaded the `resolve` function with an additional argument for `allowed_host_state`. This was necessary, instead of adding to the existing function with a default parameter, because the original function overrides a base virtual function - I can't change its arguments without also changing the base function. If you disagree with the overload, I could change its name, but I feel that it's convenient in this case.
* More contentious: I also overloaded the `srv_resolve` function, this time with both different arguments and a different return type. I expect you to disagree with this, but I'm not sure what the 'right' thing to do here is - I suspect the names should differ, but I think the name on the original is a bit crap when it returns a single string value instead of a result vector like the `resolve` function. I feel like the function I've added should be the one named `srv_resolve`.
* I added an `allowed_host_state` argument with a default parameter to `resolve_iter`, but didn't end up using it. I suspect I should just hard-code ALL_LISTS in this instance?
* I had to initialise the `ttl` ints in the `srv_resolve` functions, otherwise Valgrind complained of a memory error when `BaseResolver::srv_resolve` attempts a `std::min` comparison using the uninitialised value. I have no idea why it didn't complain about this previously, though! With that said, I think this is correct - in our production code, all of the calls to `srv_resolve` pass in an initialised `ttl` value.