### PR TITLE
[Reviewer: AJH] Move parse_ip_target tests to Utils

### DIFF
--- a/src/ut/baseresolver_test.cpp
+++ b/src/ut/baseresolver_test.cpp
@@ -105,31 +105,12 @@ class BaseResolverTest : public ResolverTest
 
     if (! targets.empty())
     {
-      output = ResolverUtils::addrinfo_to_string(targets[0]);
+      output = targets[0].to_string();
     }
 
     return output;
   }
 };
-
-// Test that basic parsing of IP addresses works
-TEST_F(BaseResolverTest, ParseIPAddresses)
-{
-  AddrInfo ai;
-  ai.port = 80;
-  ai.transport = IPPROTO_TCP;
-
-  EXPECT_TRUE(_baseresolver.parse_ip_target("1.2.3.4", ai.address));
-  EXPECT_EQ("1.2.3.4:80;transport=TCP", ResolverUtils::addrinfo_to_string(ai));
-
-  EXPECT_TRUE(_baseresolver.parse_ip_target("1:2::2", ai.address));
-  EXPECT_EQ("[1:2::2]:80;transport=TCP", ResolverUtils::addrinfo_to_string(ai));
-
-  EXPECT_TRUE(_baseresolver.parse_ip_target("[1:2::2]", ai.address));
-  EXPECT_EQ("[1:2::2]:80;transport=TCP", ResolverUtils::addrinfo_to_string(ai));
-
-  EXPECT_FALSE(_baseresolver.parse_ip_target("1.2.3.4:8888", ai.address));
-}
 
 // Test that basic IPv4 resolution works
 TEST_F(BaseResolverTest, IPv4AddressResolution)
@@ -139,7 +120,7 @@ TEST_F(BaseResolverTest, IPv4AddressResolution)
   std::vector<AddrInfo> targets = resolve(1);
   ASSERT_GT(targets.size(), 0);
 
-  std::string result = ResolverUtils::addrinfo_to_string(resolve(1)[0]);
+  std::string result = resolve(1)[0].to_string();
   EXPECT_EQ(result, "3.0.0.0:80;transport=TCP");
 }
 
@@ -151,7 +132,7 @@ TEST_F(BaseResolverTest, IPv4AddressResolutionManyTargets)
   std::vector<AddrInfo> targets = resolve(1);
   ASSERT_GT(targets.size(), 0);
 
-  std::string result = ResolverUtils::addrinfo_to_string(resolve(1)[0]);
+  std::string result = resolve(1)[0].to_string();
   EXPECT_THAT(result, MatchesRegex("3.0.0.[0-6]:80;transport=TCP"));
 }
 
@@ -482,7 +463,7 @@ TEST_F(BaseResolverTest, ARecordAllowedHostStates)
   results.pop_back();
   for (const AddrInfo& result : results)
   {
-    std::string result_str = ResolverUtils::addrinfo_to_string(result);
+    std::string result_str = result.to_string();
     EXPECT_THAT(result_str, MatchesRegex("3.0.0.[1-2]:80;transport=TCP"));
   }
 
@@ -492,7 +473,7 @@ TEST_F(BaseResolverTest, ARecordAllowedHostStates)
   EXPECT_EQ(2, results.size());
   for (const AddrInfo& result : results)
   {
-    std::string result_str = ResolverUtils::addrinfo_to_string(result);
+    std::string result_str = result.to_string();
     EXPECT_THAT(result_str, MatchesRegex("3.0.0.[1-2]:80;transport=TCP"));
   }
 
@@ -614,7 +595,7 @@ TEST_F(BaseResolverTest, SRVRecordAllowedHostStates)
   EXPECT_EQ(3, results.size());
   for (AddrInfo& result : results)
   {
-    std::string result_str = ResolverUtils::addrinfo_to_string(result);
+    std::string result_str = result.to_string();
     EXPECT_THAT(result_str, MatchesRegex(whitelist_regex));
   }
 
@@ -633,7 +614,7 @@ TEST_F(BaseResolverTest, SRVRecordAllowedHostStates)
   EXPECT_EQ(3, results.size());
   for (AddrInfo& result : results)
   {
-    std::string result_str = ResolverUtils::addrinfo_to_string(result);
+    std::string result_str = result.to_string();
     EXPECT_THAT(result_str, MatchesRegex(whitelist_regex));
   }
 
@@ -644,7 +625,7 @@ TEST_F(BaseResolverTest, SRVRecordAllowedHostStates)
   EXPECT_EQ(3, results.size());
   for (AddrInfo& result : results)
   {
-    std::string result_str = ResolverUtils::addrinfo_to_string(result);
+    std::string result_str = result.to_string();
     EXPECT_THAT(result_str, MatchesRegex(blacklist_regex));
   }
 }

--- a/src/ut/diameterresolver_test.cpp
+++ b/src/ut/diameterresolver_test.cpp
@@ -78,7 +78,7 @@ public:
     if (!targets.empty())
     {
       // Successful, so render AddrInfo as a string.
-      output = ResolverUtils::addrinfo_to_string(targets[0]);
+      output = targets[0].to_string();
     }
 
     EXPECT_EQ(expected_output, output);

--- a/src/ut/httpconnection_test.cpp
+++ b/src/ut/httpconnection_test.cpp
@@ -150,7 +150,7 @@ class HttpConnectionBlacklistTest : public BaseTest
     for (int i = 0; i < count; ++i)
     {
       os << "3.0.0." << i;
-      BaseResolver::parse_ip_target(os.str(), ai.address);
+      Utils::parse_ip_target(os.str(), ai.address);
       targets.push_back(ai);
       os.str(std::string());
     }

--- a/src/ut/resolver_test.cpp
+++ b/src/ut/resolver_test.cpp
@@ -29,7 +29,7 @@ ResolverTest::~ResolverTest()
 AddrInfo ResolverTest::ip_to_addr_info(std::string address_str, int port, int transport)
 {
   AddrInfo ai;
-  BaseResolver::parse_ip_target(address_str, ai.address);
+  Utils::parse_ip_target(address_str, ai.address);
   ai.port = port;
   ai.transport = transport;
   return ai;

--- a/src/ut/resolver_utils.h
+++ b/src/ut/resolver_utils.h
@@ -20,36 +20,6 @@ using namespace std;
 
 namespace ResolverUtils
 {
-inline std::string addrinfo_to_string(const AddrInfo& ai)
-{
-  ostringstream oss;
-  char buf[100];
-  if (ai.address.af == AF_INET6)
-  {
-    oss << "[";
-  }
-  oss << inet_ntop(ai.address.af, &ai.address.addr, buf, sizeof(buf));
-  if (ai.address.af == AF_INET6)
-  {
-    oss << "]";
-  }
-  oss << ":" << ai.port;
-  oss << ";transport=";
-  if (ai.transport == IPPROTO_SCTP)
-  {
-    oss << "SCTP";
-  }
-  else if (ai.transport == IPPROTO_TCP)
-  {
-    oss << "TCP";
-  }
-  else
-  {
-    oss << "Unknown (" << ai.transport << ")";
-  }
-  return oss.str();
-}
-
 inline DnsRRecord* a(const std::string& name,
                      int ttl,
                      const std::string& address)

--- a/src/ut/utils_test.cpp
+++ b/src/ut/utils_test.cpp
@@ -30,7 +30,7 @@ class UtilsTest : public BaseTest
 
 TEST_F(UtilsTest, ValidIPv4Address)
 {
-  EXPECT_EQ(IPAddressType::IPV4_ADDRESS, parse_ip_address("127.0.0.1")); 
+  EXPECT_EQ(IPAddressType::IPV4_ADDRESS, parse_ip_address("127.0.0.1"));
 }
 
 TEST_F(UtilsTest, ValidIPv4AddressWithPort)
@@ -147,3 +147,23 @@ TEST_F(UtilsTest, RemoveBracketsFromBareIPv6Address)
 {
   EXPECT_EQ("::1", remove_brackets_from_ip("::1"));
 }
+
+// Test that basic parsing of IP addresses works
+TEST_F(UtilsTest, ParseIPAddresses)
+{
+  AddrInfo ai;
+  ai.port = 80;
+  ai.transport = IPPROTO_TCP;
+
+  EXPECT_TRUE(parse_ip_target("1.2.3.4", ai.address));
+  EXPECT_EQ("1.2.3.4:80;transport=TCP", ai.to_string());
+
+  EXPECT_TRUE(parse_ip_target("1:2::2", ai.address));
+  EXPECT_EQ("[1:2::2]:80;transport=TCP", ai.to_string());
+
+  EXPECT_TRUE(parse_ip_target("[1:2::2]", ai.address));
+  EXPECT_EQ("[1:2::2]:80;transport=TCP", ai.to_string());
+
+  EXPECT_FALSE(parse_ip_target("1.2.3.4:8888", ai.address));
+}
+


### PR DESCRIPTION
Follow on changes from Metaswitch/cpp-common#676:
- Move the `parse_ip_target()` tests from the baseresolver to utils.
- Delete the AddrInfo to string function in ResolverUtils, and move to using the one in Utils.