### PR TITLE
[Reviewer: EM] Fix httpclient code coverage

### DIFF
--- a/src/ut/httpclient_test.cpp
+++ b/src/ut/httpclient_test.cpp
@@ -63,7 +63,11 @@ class HttpClientTest : public BaseTest
                                    true,
                                    false,
                                    // Override the default timeout for this client
-                                   1000);
+                                   1000,
+                                   // Specify a server name for this client
+                                   true,
+                                   "a_test_server"
+                                   );
 
     fakecurl_responses.clear();
     fakecurl_responses["http://10.42.42.42:80/blah/blah/blah"] = "<?xml version=\"1.0\" encoding=\"UTF-8\"><boring>Document</boring>";

--- a/src/ut/httpclient_test.cpp
+++ b/src/ut/httpclient_test.cpp
@@ -46,8 +46,11 @@ class HttpClientTest : public BaseTest
   NiceMock<MockCommunicationMonitor>* _cm = new NiceMock<MockCommunicationMonitor>(_am);
   HttpClient* _http;
   HttpClient* _private_http;
+  string _server_display_name;
+
   HttpClientTest() :
-    _resolver("10.42.42.42")
+    _resolver("10.42.42.42"),
+    _server_display_name("a_test_server")
   {
     _http = new HttpClient(true,
                            &_resolver,
@@ -66,7 +69,7 @@ class HttpClientTest : public BaseTest
                                    1000,
                                    // Specify a server name for this client
                                    true,
-                                   "a_test_server"
+                                   _server_display_name
                                    );
 
     fakecurl_responses.clear();
@@ -192,6 +195,24 @@ TEST_F(HttpClientTest, SasNoBodyToOmit)
 
   bool body_omitted = (req_event->var_params[2].find(BODY_OMITTED) != string::npos);
   EXPECT_FALSE(body_omitted);
+
+  mock_sas_collect_messages(false);
+}
+
+// Check that we correctly apply the specified display name.
+TEST_F(HttpClientTest, SasDisplayName)
+{
+  mock_sas_collect_messages(true);
+  std::map<std::string, std::string> headers;
+  headers["HttpClientTest"] = "true";
+  _private_http->send_post("http://cyrus/blah/blah/blah", headers, "", 0, "gandalf");
+
+  MockSASMessage* req_event = mock_sas_find_event(SASEvent::TX_HTTP_REQ);
+  EXPECT_TRUE(req_event != NULL);
+
+  // Ensure that display name added to SAS event matches the name we passed
+  // to the HttpClient constructor
+  EXPECT_EQ(req_event->var_params[0], _server_display_name);
 
   mock_sas_collect_messages(false);
 }


### PR DESCRIPTION
Metaswitch/cpp-common#675 has reduced code coverage below 100%, as we aren't covering the code for specifying a server name.

For this fix, we:

* Specify a display name to the private HTTP client;
* Add a unit test to check that this display name is added to the event when a request is sent.

I think specifying the display name for all tests on the private client is okay, because we're covering the non-specified case with the simpler HttpClient constructor used in the 'non-private' client. Shout if you disagree with this.