### PR TITLE
[Reviewer: Seb] Fix constructor ambiguity

### DIFF
--- a/src/ut/dnscachedresolver_test.cpp
+++ b/src/ut/dnscachedresolver_test.cpp
@@ -21,8 +21,9 @@ using namespace std;
 // manually add entries to the DnsCache
 class TestDnsCachedResolver : public  DnsCachedResolver
 {
+  std::vector<std::string> dns_servers = {"0.0.0.0"};
   TestDnsCachedResolver(string filename) :
-    DnsCachedResolver({"0.0.0.0"}, DnsCachedResolver::DEFAULT_TIMEOUT, filename)
+    DnsCachedResolver(dns_servers, DnsCachedResolver::DEFAULT_TIMEOUT, filename)
   {
     reload_static_records();
     add_fake_entries_to_cache();


### PR DESCRIPTION
As just discussed, this is to resolve the ambiguity causing the compiler error below. Tested running make test, and this file compiles now. I'm hitting a different error so can't verify tests all pass, but it's a step forward i think.

```
g++   -MMD -MP -O0 -ggdb3 -std=c++11 -Wall -Werror -DUNIT_TEST -fprofile-arcs -ftest-coverage -fno-access-control -I../modules/gmock/gtest/include -I../modules/gmock/include -I../modules/cpp-common/test_utils -Wno-write-strings -I../usr/include -I../modules/rapidjson/include -I../modules/cpp-common/include -Iut  -c ut/dnscachedresolver_test.cpp -o ../build/cpp_common_test_test/dnscachedresolver_test.o
ut/dnscachedresolver_test.cpp: In constructor ‘TestDnsCachedResolver::TestDnsCachedResolver(std::string)’:
ut/dnscachedresolver_test.cpp:25:80: error: call of overloaded ‘DnsCachedResolver(<brace-enclosed initializer list>, const int&, std::string&)’ is ambiguous
     DnsCachedResolver({"0.0.0.0"}, DnsCachedResolver::DEFAULT_TIMEOUT, filename)
                                                                                ^
ut/dnscachedresolver_test.cpp:25:80: note: candidates are:
In file included from ut/dnscachedresolver_test.cpp:16:0:
../modules/cpp-common/include/dnscachedresolver.h:63:3: note: DnsCachedResolver::DnsCachedResolver(const string&, int, const string&, int)
   DnsCachedResolver(const std::string& dns_server,
   ^
../modules/cpp-common/include/dnscachedresolver.h:59:3: note: DnsCachedResolver::DnsCachedResolver(const std::vector<std::basic_string<char> >&, int, const string&, int)
   DnsCachedResolver(const std::vector<std::string>& dns_servers,
   ^
../modules/cpp-common/include/dnscachedresolver.h:55:3: note: DnsCachedResolver::DnsCachedResolver(const std::vector<IP46Address>&, int, const string&, int) <near match>
   DnsCachedResolver(const std::vector<IP46Address>& dns_servers,
   ^
../modules/cpp-common/include/dnscachedresolver.h:55:3: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘const std::vector<IP46Address>&’
make: *** [../build/cpp_common_test_test/dnscachedresolver_test.o] Error 1
```