### PR TITLE
Dns coverage uts

### DIFF
--- a/src/ut/dns_json/bad_name.json
+++ b/src/ut/dns_json/bad_name.json
@@ -1,0 +1,22 @@
+{
+  "hostnames": [
+    {
+      "records": [
+        {
+          "rrtype": "A",
+          "target": "one.made.up.domain"
+        }
+      ]
+    },
+    {
+      "name": "two.redirected.domain",
+      "records": [
+        {
+          "rrtype": "CNAME",
+          "target": "two.made.up.domain"
+        }
+      ]
+    }
+  ]
+}
+

--- a/src/ut/dns_json/missing_hostnames.json
+++ b/src/ut/dns_json/missing_hostnames.json
@@ -1,0 +1,32 @@
+{
+  "missinghostnames": [
+    {
+      "name": "one.extra.domain",
+      "records": [
+        {
+          "rrtype": "CNAME",
+          "target": "one.made.up.domain"
+        }
+      ]
+    },
+    {
+      "name": "two.extra.domain",
+      "records": [
+        {
+          "rrtype": "CNAME",
+          "target": "two.made.up.domain"
+        }
+      ]
+    },
+    {
+      "name": "a.records.domain",
+      "records": [
+        {
+          "rrtype": "A",
+          "targets": ["10.0.0.1", "10.0.0.2"]
+        }
+      ]
+    }
+  ]
+}
+

--- a/src/ut/staticdns_test.cpp
+++ b/src/ut/staticdns_test.cpp
@@ -475,8 +475,7 @@ TEST_F(StaticDnsCacheTest, BadNameJson)
 {
   StaticDnsCache cache(DNS_JSON_DIR + "bad_name.json");
 
-  // The first entry with a missing "name" member, and the second entry with
-  // type UNKNOWN should have been skipped, but the valid CNAME record should
+  // The first entry with a missing "name" member, but the valid CNAME record should
   // have been read in.
   EXPECT_EQ(cache.size(), 1);
 

--- a/src/ut/staticdns_test.cpp
+++ b/src/ut/staticdns_test.cpp
@@ -437,8 +437,6 @@ TEST_F(StaticDnsCacheTest, DuplicateARecord)
   EXPECT_EQ(extract_a_record(first_result), "10.0.0.1");
 }
 
-
-
 TEST_F(StaticDnsCacheTest, JsonBadRrtype)
 {
   StaticDnsCache cache(DNS_JSON_DIR + "bad_rrtype_dns_config.json");
@@ -449,7 +447,6 @@ TEST_F(StaticDnsCacheTest, JsonBadRrtype)
   EXPECT_EQ(cache.size(), 1);
   EXPECT_EQ(cache.get_canonical_name("one.redirected.domain"), "one.made.up.domain");
 }
-
 
 TEST_F(StaticDnsCacheTest, JsonMultipleEntries)
 {
@@ -472,4 +469,16 @@ TEST_F(StaticDnsCacheTest, MissingHostnamesJson)
   StaticDnsCache cache(DNS_JSON_DIR + "missing_hostnames.json");
 
   EXPECT_EQ(cache.size(), 0);
+}
+
+TEST_F(StaticDnsCacheTest, BadNameJson)
+{
+  StaticDnsCache cache(DNS_JSON_DIR + "bad_name.json");
+
+  // The first entry with a missing "name" member, and the second entry with
+  // type UNKNOWN should have been skipped, but the valid CNAME record should
+  // have been read in.
+  EXPECT_EQ(cache.size(), 1);
+
+  EXPECT_EQ(cache.get_canonical_name("two.redirected.domain"), "two.made.up.domain");
 }

--- a/src/ut/staticdns_test.cpp
+++ b/src/ut/staticdns_test.cpp
@@ -466,3 +466,10 @@ TEST_F(StaticDnsCacheTest, JsonMultipleEntries)
 
   EXPECT_EQ(extract_a_record(first_result), "10.10.10.10");
 }
+
+TEST_F(StaticDnsCacheTest, MissingHostnamesJson)
+{
+  StaticDnsCache cache(DNS_JSON_DIR + "missing_hostnames.json");
+
+  EXPECT_EQ(cache.size(), 0);
+}


### PR DESCRIPTION
UTs to cover:
- Missing "name" member on a record
- Missing "hostname" member in the JSON file.